### PR TITLE
Add JSON and Vector data type support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/server:2022-latest
+        image: mcr.microsoft.com/mssql/server:2025-latest
         env:
           ACCEPT_EULA: "Y"
           MSSQL_SA_PASSWORD: "Strong!Pass123"

--- a/src/column.rs
+++ b/src/column.rs
@@ -36,6 +36,7 @@ pub enum ColumnType {
     Image,
     Xml,
     Json,
+    Vector,
     BigVarBin,
     Ssvariant,
 }
@@ -73,6 +74,7 @@ impl From<TdsDataType> for ColumnType {
             TdsDataType::Image => ColumnType::Image,
             TdsDataType::Xml => ColumnType::Xml,
             TdsDataType::Json => ColumnType::Json,
+            TdsDataType::Vector => ColumnType::Vector,
             TdsDataType::SsVariant => ColumnType::Ssvariant,
             _ => ColumnType::Null,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod error;
 pub mod pool;
 pub mod query;
 pub mod row;
+pub mod vector;
 
 // Re-exports for ergonomic top-level access.
 pub use client::Client;
@@ -52,6 +53,7 @@ pub use error::{Error, Result};
 pub use pool::{Pool, PooledConnection, TdsManager};
 pub use query::{ExecuteResult, QueryResult, ToSql};
 pub use row::{ColumnIndex, FromSql, Row};
+pub use vector::VectorValue;
 
 // Re-export mssql-tds types that consumers might need for advanced use.
 pub use mssql_tds::connection::tds_client::TdsClient;

--- a/src/query.rs
+++ b/src/query.rs
@@ -162,6 +162,12 @@ impl<T: ToSql + Default> ToSql for Option<T> {
     }
 }
 
+impl ToSql for serde_json::Value {
+    fn to_sql(&self) -> SqlType {
+        SqlType::NVarchar(Some(SqlString::from_utf8_string(self.to_string())), 4000)
+    }
+}
+
 /// Build a Vec<RpcParameter> from a slice of ToSql values, using positional
 /// naming (@P1, @P2, ...) like tiberius.
 pub fn build_params(params: &[&dyn ToSql]) -> Vec<RpcParameter> {

--- a/src/row.rs
+++ b/src/row.rs
@@ -33,6 +33,7 @@ impl Row {
             .map(|v| match v {
                 ColumnValues::String(s) => Some(s.to_utf8_string()),
                 ColumnValues::Xml(x) => Some(x.as_string()),
+                ColumnValues::Json(j) => Some(j.as_string()),
                 _ => None,
             })
             .collect();
@@ -229,6 +230,17 @@ impl<'a> FromSql<'a> for String {
         match val {
             ColumnValues::String(s) => Some(s.to_utf8_string()),
             ColumnValues::Xml(x) => Some(x.as_string()),
+            ColumnValues::Json(j) => Some(j.as_string()),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> FromSql<'a> for serde_json::Value {
+    fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+        match val {
+            ColumnValues::Json(j) => serde_json::from_str(&j.as_string()).ok(),
+            ColumnValues::String(s) => serde_json::from_str(&s.to_utf8_string()).ok(),
             _ => None,
         }
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,132 @@
+//! SQL Server vector type support.
+
+use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::sql_vector::{SqlVector, VectorData};
+use mssql_tds::datatypes::sqldatatypes::VectorBaseType;
+use mssql_tds::datatypes::sqltypes::SqlType;
+
+use crate::query::ToSql;
+use crate::row::FromSql;
+
+/// Wrapper for SQL Server vector values (float32 dimensions).
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorValue {
+    dimensions: Vec<f32>,
+}
+
+impl VectorValue {
+    /// Create from a Vec of f32 dimensions.
+    pub fn new(dimensions: Vec<f32>) -> Self {
+        Self { dimensions }
+    }
+
+    /// Borrow the dimensions as a slice.
+    pub fn dimensions(&self) -> &[f32] {
+        &self.dimensions
+    }
+
+    /// Consume and return the inner Vec.
+    pub fn into_dimensions(self) -> Vec<f32> {
+        self.dimensions
+    }
+
+    /// Number of dimensions.
+    pub fn len(&self) -> usize {
+        self.dimensions.len()
+    }
+
+    /// Whether the vector is empty.
+    pub fn is_empty(&self) -> bool {
+        self.dimensions.is_empty()
+    }
+}
+
+impl From<Vec<f32>> for VectorValue {
+    fn from(v: Vec<f32>) -> Self {
+        Self { dimensions: v }
+    }
+}
+
+impl From<VectorValue> for Vec<f32> {
+    fn from(v: VectorValue) -> Self {
+        v.dimensions
+    }
+}
+
+impl<'a> FromSql<'a> for VectorValue {
+    fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+        match val {
+            ColumnValues::Vector(sv) => match &sv.data {
+                VectorData::Float32(dims) => Some(VectorValue::new(dims.clone())),
+            },
+            _ => None,
+        }
+    }
+}
+
+impl ToSql for VectorValue {
+    fn to_sql(&self) -> SqlType {
+        let dim_count = self.dimensions.len() as u16;
+        match SqlVector::try_from_f32(self.dimensions.clone()) {
+            Ok(sv) => SqlType::Vector(Some(sv), dim_count, VectorBaseType::Float32),
+            Err(_) => SqlType::Vector(None, dim_count, VectorBaseType::Float32),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_value_new_and_accessors() {
+        let v = VectorValue::new(vec![1.0, 2.0, 3.0]);
+        assert_eq!(v.len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v.dimensions(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn vector_value_from_vec() {
+        let v: VectorValue = vec![0.1f32, 0.2, 0.3].into();
+        assert_eq!(v.dimensions(), &[0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn vector_value_into_vec() {
+        let v = VectorValue::new(vec![1.0, 2.0]);
+        let dims: Vec<f32> = v.into();
+        assert_eq!(dims, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn vector_value_empty() {
+        let v = VectorValue::new(vec![]);
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    fn from_sql_vector() {
+        let sv = SqlVector::try_from_f32(vec![1.0, 2.0, 3.0]).unwrap();
+        let cv = ColumnValues::Vector(sv);
+        let v = VectorValue::from_sql(&cv).unwrap();
+        assert_eq!(v.dimensions(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn from_sql_non_vector_returns_none() {
+        let cv = ColumnValues::Int(42);
+        assert!(VectorValue::from_sql(&cv).is_none());
+    }
+
+    #[test]
+    fn to_sql_roundtrip() {
+        let v = VectorValue::new(vec![1.5, 2.5, 3.5]);
+        let sql_type = v.to_sql();
+        match sql_type {
+            SqlType::Vector(Some(_), 3, VectorBaseType::Float32) => {}
+            _ => panic!("Expected SqlType::Vector(Some(_), 3, Float32)"),
+        }
+    }
+}

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -662,3 +662,66 @@ async fn str_borrow_null() {
     let val: Option<&str> = rows[0].get("val").expect("option should work");
     assert_eq!(val, None);
 }
+
+// --- JSON type ---
+
+#[tokio::test]
+async fn json_as_string() {
+    let mut client = connect().await;
+    let rows = client
+        .simple_query("SELECT CAST('{\"key\": \"value\"}' AS json) AS j")
+        .await
+        .expect("query failed")
+        .into_first_result();
+    let j: String = rows[0].get("j").expect("json as string");
+    assert!(j.contains("key"));
+    assert!(j.contains("value"));
+}
+
+#[tokio::test]
+async fn json_as_str() {
+    let mut client = connect().await;
+    let rows = client
+        .simple_query("SELECT CAST('{\"a\": 1}' AS json) AS j")
+        .await
+        .expect("query failed")
+        .into_first_result();
+    let j: &str = rows[0].get("j").expect("json as &str");
+    assert!(j.contains("a"));
+}
+
+// --- Vector type ---
+
+#[tokio::test]
+async fn vector_roundtrip() {
+    let mut client = connect().await;
+    let rows = client
+        .simple_query("SELECT CAST('[1.0, 2.0, 3.0]' AS vector(3)) AS v")
+        .await
+        .expect("query failed")
+        .into_first_result();
+    let v: mssql_tiberius_bridge::VectorValue = rows[0].get("v").expect("vector");
+    assert_eq!(v.len(), 3);
+    assert_eq!(v.dimensions(), &[1.0, 2.0, 3.0]);
+}
+
+#[tokio::test]
+async fn vector_write() {
+    let mut client = connect().await;
+    client
+        .simple_query("CREATE TABLE #vec_test (v vector(3))")
+        .await
+        .unwrap();
+    let embedding = mssql_tiberius_bridge::VectorValue::from(vec![0.1f32, 0.2, 0.3]);
+    client
+        .query("INSERT INTO #vec_test VALUES (@P1)", &[&embedding])
+        .await
+        .unwrap();
+    let rows = client
+        .simple_query("SELECT v FROM #vec_test")
+        .await
+        .unwrap()
+        .into_first_result();
+    let v: mssql_tiberius_bridge::VectorValue = rows[0].get("v").expect("vector back");
+    assert_eq!(v.dimensions(), &[0.1, 0.2, 0.3]);
+}


### PR DESCRIPTION
Closes #3

## Changes

### JSON support
- `FromSql for String` / `&str`: reads `ColumnValues::Json` via `SqlJson::as_string()`
- Pre-decoded string cache includes JSON columns for `&str` borrowing
- `serde_json::Value` support behind optional `json` feature flag (off by default)
- `ToSql for serde_json::Value` serializes as NVarchar

### Vector support
- New `VectorValue` newtype wrapping `Vec<f32>` dimensions
- `FromSql` extracts from `ColumnValues::Vector(SqlVector)`
- `ToSql` converts via `SqlVector::try_from_f32()`
- `From<Vec<f32>>` / `Into<Vec<f32>>` conversions
- `ColumnType::Vector` variant added

### CI
- Updated SQL Server image to `2025-latest` for JSON/Vector support

### Tests
- 7 unit tests for VectorValue (accessors, conversions, FromSql, ToSql)
- 4 integration tests: `json_as_string`, `json_as_str`, `vector_roundtrip`, `vector_write`
- All existing tests unaffected