### PR TITLE
Switch to published mssql-tds-preview from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mssql-tds"
-version = "0.1.0"
-source = "git+https://github.com/microsoft/mssql-rs#63de19de0c9d41f29650644e01b98e49c33bafc1"
+name = "mssql-tds-preview"
+version = "0.1.0-preview.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454957bed59024ea56acb311e8c0b74369182f1a3256d9e036d4b46f687d0462"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -714,7 +715,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "deadpool",
- "mssql-tds",
+ "mssql-tds-preview",
  "rust_decimal",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["database"]
 license = "MIT"
 
 [dependencies]
-mssql-tds = { git = "https://github.com/microsoft/mssql-rs", default-features = false }
+mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.1", default-features = false }
 deadpool = "0.12"
 chrono = "0.4"
 rust_decimal = "1"


### PR DESCRIPTION
Replaces the git dependency on `microsoft/mssql-rs` with the published `mssql-tds-preview 0.1.0-preview.1` from crates.io.

```toml
# Before
mssql-tds = { git = "https://github.com/microsoft/mssql-rs", default-features = false }

# After
mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.1", default-features = false }
```

All `use mssql_tds::...` imports remain unchanged via the `package` rename.

**This unblocks publishing mssql-tiberius-bridge itself to crates.io.**

30 unit tests passing, clippy clean.