### PR TITLE
Set version to 0.1.0-preview.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tiberius-bridge"
-version = "0.1.0"
+version = "0.1.0-preview.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-tiberius-bridge"
-version = "0.1.0"
+version = "0.1.0-preview.1"
 edition = "2021"
 description = "A tiberius-compatible API bridge over Microsoft's mssql-tds crate. Migrate from tiberius with minimal code changes."
 repository = "https://github.com/saurabh500/mssql-tiberius-bridge"


### PR DESCRIPTION
Aligns with the preview versioning scheme used by mssql-tds-preview.

Version scheme: `{base}-preview.{N}` until APIs stabilize.