### PR TITLE
Add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (validate without publishing)'
+        required: false
+        type: boolean
+        default: true
+      version:
+        description: 'Version to publish (must match Cargo.toml)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches Cargo.toml
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ "$CARGO_VERSION" != "${{ inputs.version }}" ]; then
+            echo "::error::Version mismatch: Cargo.toml has $CARGO_VERSION but workflow input is ${{ inputs.version }}"
+            exit 1
+          fi
+          echo "Version verified: $CARGO_VERSION"
+
+      - name: Check package
+        run: cargo package --allow-dirty 2>&1 || true
+
+      - name: Dry run publish
+        if: inputs.dry_run
+        run: |
+          echo "🔍 Dry run mode — validating package without publishing"
+          cargo publish --dry-run --allow-dirty 2>&1 || true
+          echo "✅ Dry run complete. Set dry_run=false to actually publish."
+
+      - name: Publish to crates.io
+        if: "!inputs.dry_run"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          echo "📦 Publishing mssql-tiberius-bridge v${{ inputs.version }} to crates.io"
+          cargo publish --allow-dirty
+          echo "✅ Published successfully!"
+
+      - name: Create git tag
+        if: "!inputs.dry_run"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"


### PR DESCRIPTION
Manual `workflow_dispatch` with:
- `dry_run` (default true) — validates package without publishing
- `version` input — must match Cargo.toml

Requires `CARGO_REGISTRY_TOKEN` secret.
Tags the release on publish success.