### PR TITLE
refactor: expose Column fields via getter methods

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -85,14 +85,29 @@ impl From<TdsDataType> for ColumnType {
 #[derive(Debug, Clone)]
 pub struct Column {
     /// Column name.
-    pub name: String,
+    pub(crate) name: String,
     /// Column data type.
-    pub column_type: ColumnType,
+    pub(crate) column_type: ColumnType,
     /// Whether the column is nullable.
-    pub nullable: bool,
+    pub(crate) nullable: bool,
 }
 
 impl Column {
+    /// Returns the column name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the column data type.
+    pub fn column_type(&self) -> ColumnType {
+        self.column_type
+    }
+
+    /// Returns whether the column is nullable.
+    pub fn nullable(&self) -> bool {
+        self.nullable
+    }
+
     /// Create a Column from mssql-tds ColumnMetadata.
     pub fn from_tds(meta: &mssql_tds::query::metadata::ColumnMetadata) -> Self {
         Column {

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -633,8 +633,8 @@ async fn column_metadata() {
         .unwrap()
         .into_first_result();
     let cols = rows[0].columns();
-    assert_eq!(cols[0].name, "answer");
-    assert_eq!(cols[1].name, "greeting");
+    assert_eq!(cols[0].name(), "answer");
+    assert_eq!(cols[1].name(), "greeting");
 }
 
 // --- &str borrowing (tiberius compat) ---


### PR DESCRIPTION
Make `Column` fields `pub(crate)` and add `name()`, `column_type()`, and `nullable()` getter methods.

This matches tiberius's API surface where these were methods, not public fields, making it easier for consumers (like Tabularis) migrating from tiberius to use the bridge as a drop-in replacement.

### Changes
- `src/column.rs`: Fields changed from `pub` to `pub(crate)`, added `name()`, `column_type()`, `nullable()` methods
- `tests/tiberius_compat.rs`: Updated field access to use getter methods