### PR TITLE
feat(config): add Config::trust_cert_ca for CA pinning (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A tiberius-compatible API bridge over Microsoft's [`mssql-tds`](https://github.c
 - `stream.into_first_result()` — collect results into `Vec<Row>`
 - `conn.query(sql, &[&param])` — positional `@P1, @P2` parameters
 - `Config::new().host().port().trust_cert()` — fluent builder
+- `Config::trust_cert_ca("ca.pem")` — pin a CA certificate (mirrors tiberius)
 - deadpool connection pooling out of the box
 
 ## Quick Start

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,7 @@ pub struct Config {
     database: String,
     auth: AuthMethod,
     trust_cert: bool,
+    server_certificate: Option<String>,
     encryption: EncryptionLevel,
     application_name: Option<String>,
     instance_name: Option<String>,
@@ -112,6 +113,7 @@ impl Config {
                 password: String::new(),
             },
             trust_cert: false,
+            server_certificate: None,
             encryption: EncryptionLevel::On,
             application_name: None,
             instance_name: None,
@@ -148,6 +150,30 @@ impl Config {
     /// certificate validation.
     pub fn trust_cert(&mut self) -> &mut Self {
         self.trust_cert = true;
+        self
+    }
+
+    /// Pin the server's TLS certificate to the DER- or PEM-encoded X.509
+    /// file at `path`.
+    ///
+    /// When set, the driver bypasses standard CA chain validation and
+    /// performs an exact binary match between the file and the certificate
+    /// presented by the server. Mirrors tiberius' `Config::trust_cert_ca`.
+    ///
+    /// `trust_cert_ca` and [`trust_cert`](Self::trust_cert) are mutually
+    /// exclusive — `trust_cert_ca` takes precedence and `trust_cert` is
+    /// ignored if both are set.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mssql_tiberius_bridge::Config;
+    ///
+    /// let mut cfg = Config::new();
+    /// cfg.host("db.internal").trust_cert_ca("/etc/ssl/private-ca.pem");
+    /// ```
+    pub fn trust_cert_ca(&mut self, path: impl Into<String>) -> &mut Self {
+        self.server_certificate = Some(path.into());
         self
     }
 
@@ -211,6 +237,7 @@ impl Config {
         }
 
         ctx.encryption_options.trust_server_certificate = self.trust_cert;
+        ctx.encryption_options.server_certificate = self.server_certificate.clone();
 
         match self.encryption {
             EncryptionLevel::Off => ctx.encryption_options.mode = EncryptionSetting::PreferOff,
@@ -276,6 +303,30 @@ mod tests {
         assert_eq!(ctx.password, "pass123");
         assert_eq!(ctx.database, "mydb");
         assert!(ctx.encryption_options.trust_server_certificate);
+    }
+
+    #[test]
+    fn trust_cert_ca_sets_server_certificate() {
+        let mut cfg = Config::new();
+        cfg.trust_cert_ca("/etc/ssl/ca.pem");
+        let ctx = cfg.to_client_context();
+        assert_eq!(
+            ctx.encryption_options.server_certificate.as_deref(),
+            Some("/etc/ssl/ca.pem")
+        );
+        assert!(!ctx.encryption_options.trust_server_certificate);
+    }
+
+    #[test]
+    fn trust_cert_ca_independent_of_trust_cert() {
+        let mut cfg = Config::new();
+        cfg.trust_cert().trust_cert_ca("/tmp/ca.pem");
+        let ctx = cfg.to_client_context();
+        assert!(ctx.encryption_options.trust_server_certificate);
+        assert_eq!(
+            ctx.encryption_options.server_certificate.as_deref(),
+            Some("/tmp/ca.pem")
+        );
     }
 
     #[test]

--- a/tests/custom_cert.rs
+++ b/tests/custom_cert.rs
@@ -1,0 +1,66 @@
+//! Integration tests for `Config::trust_cert_ca` (issue #18).
+//!
+//! Mirrors `tiberius/tests/custom-cert.rs`. The positive test
+//! (`connect_with_trusted_ca`) requires a PEM/DER file matching the SQL
+//! Server's TLS certificate and is run only when `BRIDGE_CUSTOM_CA_PATH`
+//! is set.
+
+use mssql_tiberius_bridge::{AuthMethod, Client, Config, EncryptionLevel};
+
+fn base_config() -> Config {
+    let password = std::env::var("TEST_DB_PASSWORD").unwrap_or_else(|_| {
+        eprintln!("TEST_DB_PASSWORD not set, skipping");
+        std::process::exit(0);
+    });
+    let mut cfg = Config::new();
+    cfg.host(std::env::var("TEST_DB_HOST").unwrap_or_else(|_| "localhost".into()))
+        .port(
+            std::env::var("TEST_DB_PORT")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(1433),
+        )
+        .database(std::env::var("TEST_DB_NAME").unwrap_or_else(|_| "master".into()))
+        .authentication(AuthMethod::sql_server(
+            std::env::var("TEST_DB_USER").unwrap_or_else(|_| "sa".into()),
+            password,
+        ));
+    cfg
+}
+
+/// Negative case: encryption required, no CA pinned, no trust_cert ⇒ connect fails.
+/// Equivalent to tiberius `connect_to_custom_cert_instance_without_ca`.
+#[tokio::test]
+async fn connect_without_ca_fails() {
+    let mut cfg = base_config();
+    cfg.encryption(EncryptionLevel::On);
+    let result = Client::connect(&cfg).await;
+    assert!(
+        result.is_err(),
+        "expected TLS validation to fail when no CA is trusted"
+    );
+}
+
+/// Positive case: pin the CA cert and connect successfully.
+/// Set `BRIDGE_CUSTOM_CA_PATH` to a PEM/DER file that matches the
+/// server's TLS certificate. Mirrors tiberius `connect_to_custom_cert_instance_*`.
+#[tokio::test]
+async fn connect_with_trusted_ca() {
+    let Ok(ca_path) = std::env::var("BRIDGE_CUSTOM_CA_PATH") else {
+        eprintln!("BRIDGE_CUSTOM_CA_PATH not set, skipping");
+        return;
+    };
+    let mut cfg = base_config();
+    cfg.encryption(EncryptionLevel::On).trust_cert_ca(&ca_path);
+
+    let mut client = Client::connect(&cfg)
+        .await
+        .expect("connect with pinned CA failed");
+
+    let row = client
+        .query("SELECT @P1", &[&-4i32])
+        .await
+        .expect("query failed")
+        .into_first_result();
+    assert_eq!(row[0].get::<i32, _>(0usize), Some(-4));
+}


### PR DESCRIPTION
Closes #18.

## Summary
Adds `Config::trust_cert_ca(path)`, mirroring tiberius. Pipes the
path through to `mssql-tds`'s
`EncryptionOptions.server_certificate`, which already implements
certificate pinning (exact-binary match against the server's TLS
cert, bypassing CA chain validation). This unblocks Windmill's
`MSSQL_ROOT_CERTIFICATE_PEM` flow.

## API
```rust
let mut cfg = Config::new();
cfg.host("db.internal").trust_cert_ca("/etc/ssl/private-ca.pem");
```

## Tests
- Two builder unit tests in `src/config.rs` covering wiring and
  coexistence with `trust_cert`.
- New `tests/custom_cert.rs` integration tests modeled on
  `tiberius/tests/custom-cert.rs`:
  - `connect_without_ca_fails` — runs unconditionally; asserts
    encryption-required + no CA + no trust ⇒ connect fails.
  - `connect_with_trusted_ca` — gated on `BRIDGE_CUSTOM_CA_PATH`;
    pins the CA and runs a parameterized SELECT.

## Compat note
`trust_cert_ca` and `trust_cert` are independent setters; if both
are set, `mssql-tds` documents that ServerCertificate takes
precedence and warns. Behavior matches tiberius.

Part of the windmill migration umbrella #21.