### PR TITLE
feat(query): ToSql for Vec<u8>, &[u8], and chrono date/time types (#13)

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -197,6 +197,101 @@ impl ToSql for serde_json::Value {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Binary
+// ---------------------------------------------------------------------------
+
+impl ToSql for Vec<u8> {
+    fn to_sql(&self) -> SqlType {
+        SqlType::VarBinaryMax(Some(self.clone()))
+    }
+}
+
+impl ToSql for &[u8] {
+    fn to_sql(&self) -> SqlType {
+        SqlType::VarBinaryMax(Some(self.to_vec()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chrono date/time
+// ---------------------------------------------------------------------------
+
+// chrono is an unconditional dep on the bridge; FromSql for these types
+// already lives in `row.rs`, so the ToSql side is provided unconditionally too.
+mod chrono_to_sql {
+    use super::{SqlType, ToSql};
+    use chrono::{
+        DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc,
+    };
+    use mssql_tds::datatypes::column_values::{
+        SqlDate, SqlDateTime2, SqlDateTimeOffset, SqlTime, DEFAULT_VARTIME_SCALE,
+    };
+
+    fn naive_date_to_sql(d: &NaiveDate) -> SqlDate {
+        // SqlDate stores days where 0 = 0001-01-01; chrono's num_days_from_ce
+        // counts 0001-01-01 as day 1.
+        let days = (d.num_days_from_ce() - 1) as u32;
+        SqlDate::create(days).expect("date out of SQL Server DATE range (0001-01-01..=9999-12-31)")
+    }
+
+    fn naive_time_to_sql(t: &NaiveTime) -> SqlTime {
+        // SqlTime.time_nanoseconds is actually in 100-nanosecond units (mirrors
+        // the FromSql side in row.rs).
+        let nanos_since_midnight =
+            (t.num_seconds_from_midnight() as u64) * 1_000_000_000 + t.nanosecond() as u64;
+        SqlTime {
+            time_nanoseconds: nanos_since_midnight / 100,
+            scale: DEFAULT_VARTIME_SCALE,
+        }
+    }
+
+    fn naive_dt_to_sql(dt: &NaiveDateTime) -> SqlDateTime2 {
+        SqlDateTime2 {
+            days: (dt.date().num_days_from_ce() - 1) as u32,
+            time: naive_time_to_sql(&dt.time()),
+        }
+    }
+
+    impl ToSql for NaiveDate {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Date(Some(naive_date_to_sql(self)))
+        }
+    }
+
+    impl ToSql for NaiveTime {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Time(Some(naive_time_to_sql(self)))
+        }
+    }
+
+    impl ToSql for NaiveDateTime {
+        fn to_sql(&self) -> SqlType {
+            SqlType::DateTime2(Some(naive_dt_to_sql(self)))
+        }
+    }
+
+    impl ToSql for DateTime<FixedOffset> {
+        fn to_sql(&self) -> SqlType {
+            // Storage matches FromSql: dt2 holds the UTC components, offset is
+            // the original tz offset in minutes.
+            let datetime2 = naive_dt_to_sql(&self.naive_utc());
+            let offset = (self.offset().local_minus_utc() / 60) as i16;
+            SqlType::DateTimeOffset(Some(SqlDateTimeOffset { datetime2, offset }))
+        }
+    }
+
+    impl ToSql for DateTime<Utc> {
+        fn to_sql(&self) -> SqlType {
+            let datetime2 = naive_dt_to_sql(&self.naive_utc());
+            SqlType::DateTimeOffset(Some(SqlDateTimeOffset {
+                datetime2,
+                offset: 0,
+            }))
+        }
+    }
+}
+
 /// Build a Vec<RpcParameter> from a slice of ToSql values, using positional
 /// naming (@P1, @P2, ...) like tiberius.
 pub fn build_params(params: &[&dyn ToSql]) -> Vec<RpcParameter> {

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -403,6 +403,109 @@ async fn binary_type() {
 }
 
 // =============================================================================
+// 5b. ToSql round-trips for binary/chrono (issue #13)
+// =============================================================================
+
+#[tokio::test]
+async fn vec_u8_param_roundtrip() {
+    let mut client = connect().await;
+    let payload: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF];
+    let row = client
+        .query("SELECT @P1", &[&payload])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<Vec<u8>, _>(0usize), Some(payload));
+}
+
+#[tokio::test]
+async fn empty_vec_u8_param_roundtrip() {
+    let mut client = connect().await;
+    let payload: Vec<u8> = vec![];
+    let row = client
+        .query("SELECT @P1", &[&payload])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<Vec<u8>, _>(0usize), Some(payload));
+}
+
+#[tokio::test]
+async fn naive_date_param_roundtrip() {
+    let mut client = connect().await;
+    let d = chrono::NaiveDate::from_ymd_opt(2024, 7, 4).unwrap();
+    let row = client
+        .query("SELECT @P1", &[&d])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<chrono::NaiveDate, _>(0usize), Some(d));
+}
+
+#[tokio::test]
+async fn naive_time_param_roundtrip() {
+    let mut client = connect().await;
+    let t = chrono::NaiveTime::from_hms_nano_opt(12, 34, 56, 789_000_000).unwrap();
+    let row = client
+        .query("SELECT @P1", &[&t])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<chrono::NaiveTime, _>(0usize), Some(t));
+}
+
+#[tokio::test]
+async fn naive_date_time_param_roundtrip() {
+    let mut client = connect().await;
+    let dt = chrono::NaiveDate::from_ymd_opt(1999, 12, 31)
+        .unwrap()
+        .and_hms_milli_opt(23, 59, 58, 250)
+        .unwrap();
+    let row = client
+        .query("SELECT @P1", &[&dt])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<chrono::NaiveDateTime, _>(0usize), Some(dt));
+}
+
+#[tokio::test]
+async fn datetime_fixed_offset_param_roundtrip() {
+    use chrono::TimeZone;
+    let mut client = connect().await;
+    let dt = chrono::FixedOffset::east_opt(2 * 3600)
+        .unwrap()
+        .with_ymd_and_hms(2024, 1, 15, 9, 30, 0)
+        .unwrap();
+    let row = client
+        .query("SELECT @P1", &[&dt])
+        .await
+        .unwrap()
+        .into_first_result();
+    let got = row[0]
+        .get::<chrono::DateTime<chrono::FixedOffset>, _>(0usize)
+        .unwrap();
+    assert_eq!(got, dt);
+}
+
+#[tokio::test]
+async fn datetime_utc_param_sends_offset_zero() {
+    use chrono::TimeZone;
+    let mut client = connect().await;
+    let dt_utc = chrono::Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap();
+    let row = client
+        .query("SELECT @P1", &[&dt_utc])
+        .await
+        .unwrap()
+        .into_first_result();
+    let got = row[0]
+        .get::<chrono::DateTime<chrono::FixedOffset>, _>(0usize)
+        .unwrap();
+    assert_eq!(got.naive_utc(), dt_utc.naive_utc());
+    assert_eq!(got.offset().local_minus_utc(), 0);
+}
+
+// =============================================================================
 // 6. Multiple rows and result sets
 // =============================================================================
 


### PR DESCRIPTION
Closes #13.

Adds the missing write-side parameter binding for binary blobs and chrono
date/time, matching the FromSql impls that already live in `row.rs`.

## New ToSql impls
| Rust type | SQL Server type |
| --- | --- |
| `Vec<u8>`, `&[u8]` | `varbinary(max)` |
| `chrono::NaiveDate` | `date` |
| `chrono::NaiveTime` | `time` (scale 7) |
| `chrono::NaiveDateTime` | `datetime2` |
| `chrono::DateTime<FixedOffset>` | `datetimeoffset` |
| `chrono::DateTime<Utc>` | `datetimeoffset` (offset 0) |

The chrono helpers construct `SqlDate` / `SqlTime` / `SqlDateTime2` /
`SqlDateTimeOffset` from `mssql-tds` using the same conventions as the
existing FromSql side (days from CE; time in 100-ns units; offset in
minutes).

## Tests
7 new round-trip integration tests in `tests/tiberius_compat.rs`:
`vec_u8_param_roundtrip`, `empty_vec_u8_param_roundtrip`,
`naive_date_param_roundtrip`, `naive_time_param_roundtrip`,
`naive_date_time_param_roundtrip`,
`datetime_fixed_offset_param_roundtrip`,
`datetime_utc_param_sends_offset_zero`.

Verified locally against MSSQL 2025: 45/45 `tiberius_compat` tests pass.

Part of windmill migration umbrella #21.