### PR TITLE
feat(config): add Config::readonly for ApplicationIntent=ReadOnly (#15)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,7 @@ pub struct Config {
     auth: AuthMethod,
     trust_cert: bool,
     server_certificate: Option<String>,
+    readonly: bool,
     encryption: EncryptionLevel,
     application_name: Option<String>,
     instance_name: Option<String>,
@@ -114,6 +115,7 @@ impl Config {
             },
             trust_cert: false,
             server_certificate: None,
+            readonly: false,
             encryption: EncryptionLevel::On,
             application_name: None,
             instance_name: None,
@@ -174,6 +176,16 @@ impl Config {
     /// ```
     pub fn trust_cert_ca(&mut self, path: impl Into<String>) -> &mut Self {
         self.server_certificate = Some(path.into());
+        self
+    }
+
+    /// Send `ApplicationIntent=ReadOnly` in the login (mirrors tiberius'
+    /// `Config::readonly`). Required for routing to a readable secondary in
+    /// an Always On availability group / Azure SQL geo-replica.
+    ///
+    /// Defaults to `ReadWrite`.
+    pub fn readonly(&mut self, readonly: bool) -> &mut Self {
+        self.readonly = readonly;
         self
     }
 
@@ -259,6 +271,12 @@ impl Config {
         // Login7 client_prog_ver from the bridge crate version
         ctx.driver_version = DriverVersion::from_cargo_version();
 
+        ctx.application_intent = if self.readonly {
+            mssql_tds::message::login_options::ApplicationIntent::ReadOnly
+        } else {
+            mssql_tds::message::login_options::ApplicationIntent::ReadWrite
+        };
+
         // UserAgent feature extension (TDS 0x10)
         let bridge_version = env!("CARGO_PKG_VERSION");
         ctx.user_agent.set_library_name(DRIVER_NAME.to_string());
@@ -326,6 +344,26 @@ mod tests {
         assert_eq!(
             ctx.encryption_options.server_certificate.as_deref(),
             Some("/tmp/ca.pem")
+        );
+    }
+
+    #[test]
+    fn readonly_sets_application_intent() {
+        use mssql_tds::message::login_options::ApplicationIntent;
+        let mut cfg = Config::new();
+        assert_eq!(
+            cfg.to_client_context().application_intent,
+            ApplicationIntent::ReadWrite
+        );
+        cfg.readonly(true);
+        assert_eq!(
+            cfg.to_client_context().application_intent,
+            ApplicationIntent::ReadOnly
+        );
+        cfg.readonly(false);
+        assert_eq!(
+            cfg.to_client_context().application_intent,
+            ApplicationIntent::ReadWrite
         );
     }
 

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -506,6 +506,33 @@ async fn datetime_utc_param_sends_offset_zero() {
 }
 
 // =============================================================================
+// 5c. Connection options — Config::readonly (issue #15)
+// =============================================================================
+
+/// `Config::readonly(true)` must surface `ApplicationIntent=ReadOnly` in the
+/// Login7 packet. The unit test in `src/config.rs` verifies the
+/// `ClientContext.application_intent` field; this test verifies the login is
+/// accepted by SQL Server end-to-end. (Bridge #15.)
+///
+/// Note: standalone SQL Server doesn't expose the negotiated value via
+/// `CONNECTIONPROPERTY('client_app_intent')` (always NULL), so a true
+/// observable round-trip requires Always On / Azure SQL geo-replicas.
+#[tokio::test]
+async fn readonly_login_smoke() {
+    let mut cfg = test_config();
+    cfg.readonly(true);
+    let mut client = Client::connect(&cfg)
+        .await
+        .expect("login with readonly=true");
+    let row = client
+        .query("SELECT 1", &[])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(row[0].get::<i32, _>(0usize), Some(1));
+}
+
+// =============================================================================
 // 6. Multiple rows and result sets
 // =============================================================================
 


### PR DESCRIPTION
Closes #15. Adds `Config::readonly(bool)` mirroring tiberius. Pipes through to `ClientContext.application_intent`, which `mssql-tds` already serializes into the Login7 `TypeFlags`. Required by Windmill's `MSSQL_READONLY_APPLICATION_INTENT` setting.

## Tests
- Unit test toggles `application_intent` between ReadWrite/ReadOnly.
- Integration smoke test (`readonly_login_smoke`) confirms the login is accepted with `readonly=true`.

A true observable round-trip needs an AG / Azure SQL geo-replica — standalone SQL Server returns NULL for `CONNECTIONPROPERTY('client_app_intent')`. Documented in the test.

Part of windmill migration umbrella #21.