### PR TITLE
feat(auth): add AuthMethod::aad_token for Entra ID federated auth (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A tiberius-compatible API bridge over Microsoft's [`mssql-tds`](https://github.c
 - `conn.query(sql, &[&param])` — positional `@P1, @P2` parameters
 - `Config::new().host().port().trust_cert()` — fluent builder
 - `Config::trust_cert_ca("ca.pem")` — pin a CA certificate (mirrors tiberius)
+- `AuthMethod::aad_token(jwt)` — Microsoft Entra ID / AAD federated auth
 - deadpool connection pooling out of the box
 
 ## Quick Start

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,10 @@ pub enum AuthMethod {
     SqlServer { user: String, password: String },
     /// Windows Integrated authentication (Kerberos/NTLM).
     Integrated,
+    /// Microsoft Entra ID (Azure AD) federated authentication using a
+    /// pre-acquired access token (JWT). Acquire the token from MSAL /
+    /// `azure_identity` / `oauth2`, scoped for `https://database.windows.net/.default`.
+    AadToken { token: String },
 }
 
 impl AuthMethod {
@@ -71,6 +75,14 @@ impl AuthMethod {
     /// Create Windows Integrated authentication.
     pub fn integrated() -> Self {
         AuthMethod::Integrated
+    }
+
+    /// Create AAD/Entra ID federated authentication from a pre-acquired
+    /// access token (JWT). Mirrors tiberius' `AuthMethod::aad_token`.
+    pub fn aad_token(token: impl Into<String>) -> Self {
+        AuthMethod::AadToken {
+            token: token.into(),
+        }
     }
 }
 
@@ -246,6 +258,10 @@ impl Config {
             AuthMethod::Integrated => {
                 ctx.tds_authentication_method = TdsAuthenticationMethod::SSPI;
             }
+            AuthMethod::AadToken { token } => {
+                ctx.tds_authentication_method = TdsAuthenticationMethod::AccessToken;
+                ctx.access_token = Some(token.clone());
+            }
         }
 
         ctx.encryption_options.trust_server_certificate = self.trust_cert;
@@ -383,6 +399,21 @@ mod tests {
             ctx.tds_authentication_method,
             TdsAuthenticationMethod::SSPI
         ));
+    }
+
+    #[test]
+    fn aad_token_sets_access_token() {
+        let mut cfg = Config::new();
+        cfg.authentication(AuthMethod::aad_token("eyJ0eXAi.fake.jwt"));
+        let ctx = cfg.to_client_context();
+        assert!(matches!(
+            ctx.tds_authentication_method,
+            TdsAuthenticationMethod::AccessToken
+        ));
+        assert_eq!(ctx.access_token.as_deref(), Some("eyJ0eXAi.fake.jwt"));
+        // user_name/password must remain empty when using AAD
+        assert!(ctx.user_name.is_empty());
+        assert!(ctx.password.is_empty());
     }
 
     #[test]

--- a/tests/aad_token.rs
+++ b/tests/aad_token.rs
@@ -1,0 +1,38 @@
+//! AAD/Entra ID federated auth integration test (issue #17).
+//!
+//! Gated on `BRIDGE_AAD_TOKEN` (a JWT for `https://database.windows.net/.default`)
+//! plus the standard `TEST_DB_*` env vars pointing at an AAD-enabled SQL
+//! Server (Azure SQL DB or Managed Instance).
+
+use mssql_tiberius_bridge::{AuthMethod, Client, Config, EncryptionLevel};
+
+#[tokio::test]
+async fn aad_token_login() {
+    let Ok(token) = std::env::var("BRIDGE_AAD_TOKEN") else {
+        eprintln!("BRIDGE_AAD_TOKEN not set, skipping");
+        return;
+    };
+    let host = std::env::var("TEST_DB_HOST").unwrap_or_else(|_| "localhost".into());
+    let port: u16 = std::env::var("TEST_DB_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(1433);
+    let database = std::env::var("TEST_DB_NAME").unwrap_or_else(|_| "master".into());
+
+    let mut cfg = Config::new();
+    cfg.host(host)
+        .port(port)
+        .database(database)
+        .encryption(EncryptionLevel::Required)
+        .authentication(AuthMethod::aad_token(token));
+
+    let mut client = Client::connect(&cfg).await.expect("AAD login failed");
+    let row = client
+        .query("SELECT SUSER_SNAME()", &[])
+        .await
+        .unwrap()
+        .into_first_result();
+    let sname = row[0].get::<&str, _>(0usize);
+    assert!(sname.is_some(), "SUSER_SNAME() returned NULL");
+    eprintln!("AAD login as: {sname:?}");
+}


### PR DESCRIPTION
Closes #17.

Adds `AuthMethod::aad_token(jwt)` mirroring tiberius. The bearer JWT
(acquired out-of-band, e.g., via `azure_identity` / MSAL, scoped for
`https://database.windows.net/.default`) is wired into mssql-tds via
`ClientContext.access_token` + `tds_authentication_method =
TdsAuthenticationMethod::AccessToken`, which sends the FedAuth feature
extension in Login7 and the token in the FEDAUTHTOKEN message.

Unblocks Windmill's Azure SQL / Fabric AAD authentication path — the
highest-priority blocker from the migration analysis.

## API
```rust
let token: String = acquire_aad_token().await?;
let mut cfg = Config::new();
cfg.host("my-server.database.windows.net")
   .database("mydb")
   .encryption(EncryptionLevel::Required)
   .authentication(AuthMethod::aad_token(token));
let mut client = Client::connect(&cfg).await?;
```

## Tests
- Unit test: verifies `ClientContext.access_token` is set and
  user_name/password remain empty.
- Integration test (`tests/aad_token.rs`) gated on `BRIDGE_AAD_TOKEN`
  env var; runs `SELECT SUSER_SNAME()` to confirm the AAD principal
  authenticated end-to-end.

Part of windmill migration umbrella #21.