### PR TITLE
fix(config): trigger SSRP when instance_name is set (#14)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -178,10 +178,19 @@ impl Config {
 
     /// Build the TDS datasource string used by `TdsConnectionProvider`.
     ///
-    /// Format: `tcp:host,port` or `tcp:host,port\instance`.
+    /// Format:
+    /// - `tcp:host,port` (default — explicit port)
+    /// - `tcp:host\instance` (when [`instance_name`](Self::instance_name) is
+    ///   set — port is omitted so `mssql-tds` runs SSRP / SQL Browser to
+    ///   resolve the instance's TCP port)
+    ///
+    /// Per MDAC convention, including both an explicit port and an instance
+    /// name causes the instance to be silently ignored, so the bridge drops
+    /// the port whenever an instance is specified. If you need a fixed port,
+    /// don't call [`instance_name`](Self::instance_name).
     pub fn datasource_string(&self) -> String {
         if let Some(ref inst) = self.instance_name {
-            format!("tcp:{},{}\\{}", self.host, self.port, inst)
+            format!("tcp:{}\\{}", self.host, inst)
         } else {
             format!("tcp:{},{}", self.host, self.port)
         }
@@ -282,7 +291,16 @@ mod tests {
     fn instance_name_in_datasource() {
         let mut cfg = Config::new();
         cfg.host("server").instance_name("SQLEXPRESS");
-        assert_eq!(cfg.datasource_string(), "tcp:server,1433\\SQLEXPRESS");
+        // Port is omitted when an instance name is set so mssql-tds runs SSRP.
+        assert_eq!(cfg.datasource_string(), "tcp:server\\SQLEXPRESS");
+    }
+
+    #[test]
+    fn instance_name_overrides_port_in_datasource() {
+        let mut cfg = Config::new();
+        cfg.host("server").port(14330).instance_name("SQLEXPRESS");
+        // Even with an explicit port, instance triggers SSRP; port is dropped.
+        assert_eq!(cfg.datasource_string(), "tcp:server\\SQLEXPRESS");
     }
 
     #[test]

--- a/tests/ssrp.rs
+++ b/tests/ssrp.rs
@@ -1,0 +1,47 @@
+//! SSRP / SQL Browser instance lookup integration test (issue #14).
+//!
+//! Skipped unless `BRIDGE_SSRP_HOST` and `BRIDGE_SSRP_INSTANCE` are set,
+//! because the standard MSSQL Docker images don't run the SQL Browser
+//! service (UDP 1434).
+//!
+//! Example:
+//!     BRIDGE_SSRP_HOST=mssql.lab \
+//!     BRIDGE_SSRP_INSTANCE=SQLEXPRESS \
+//!     TEST_DB_USER=sa TEST_DB_PASSWORD=... \
+//!     cargo test --test ssrp -- --nocapture
+
+use mssql_tiberius_bridge::{AuthMethod, Client, Config};
+
+#[tokio::test]
+async fn ssrp_named_instance_connect() {
+    let Ok(host) = std::env::var("BRIDGE_SSRP_HOST") else {
+        eprintln!("BRIDGE_SSRP_HOST not set, skipping");
+        return;
+    };
+    let Ok(instance) = std::env::var("BRIDGE_SSRP_INSTANCE") else {
+        eprintln!("BRIDGE_SSRP_INSTANCE not set, skipping");
+        return;
+    };
+    let user = std::env::var("TEST_DB_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("TEST_DB_PASSWORD").expect("TEST_DB_PASSWORD required");
+    let database = std::env::var("TEST_DB_NAME").unwrap_or_else(|_| "master".into());
+
+    let mut cfg = Config::new();
+    cfg.host(host)
+        .instance_name(instance)
+        .database(database)
+        .authentication(AuthMethod::sql_server(user, password))
+        .trust_cert();
+
+    let mut client = Client::connect(&cfg)
+        .await
+        .expect("SSRP-resolved connect failed");
+    let row = client
+        .query("SELECT @@SERVERNAME", &[])
+        .await
+        .unwrap()
+        .into_first_result();
+    let server_name = row[0].get::<&str, _>(0usize);
+    assert!(server_name.is_some());
+    eprintln!("SSRP-resolved @@SERVERNAME: {:?}", server_name);
+}


### PR DESCRIPTION
Closes #14.

## The bug
`Config::datasource_string()` emitted `tcp:host,port\\instance` whenever an instance was set. `mssql-tds`'s `needs_ssrp()` (and the underlying MDAC convention) silently ignores the instance when an explicit port is also present:

> `tcp:server,port\\instance` → SSRP is NOT required (instance is ignored per MDAC behavior)

So `Config::instance_name(...)` looked like it worked but never actually triggered SQL Browser lookup — the connection always went to the explicit port.

## The fix
When `instance_name` is set, `datasource_string()` now emits `tcp:host\\instance` (no port). `mssql-tds`'s connection action chain detects this and runs SSRP. The `mssql-tds-preview = 0.1.0-preview.1` we depend on already ships the full SSRP implementation (UDP/1434 CLNT_UCAST_INST + response parsing + transport list).

## Behavior change
If a caller set both `port(...)` and `instance_name(...)`, the previous behavior was "use port, ignore instance" (per MDAC). The new behavior is "use instance via SSRP, drop port". Documented on `datasource_string` and `instance_name`. Practically nobody should be setting both — they're mutually exclusive options for picking the endpoint.

## Tests
- Updated `instance_name_in_datasource` for the new format.
- Added `instance_name_overrides_port_in_datasource` covering the deliberate port-drop.
- New `tests/ssrp.rs` gated on `BRIDGE_SSRP_HOST` / `BRIDGE_SSRP_INSTANCE` — skipped on the default Docker MSSQL container which doesn't run SQL Browser.

Part of windmill migration umbrella #21.