### PR TITLE
feat(auth): feature-gate AuthMethod::Integrated (#16)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,12 @@ tokio = { version = "1", features = ["net"] }
 serde_json = "1"
 async-trait = "0.1"
 thiserror = "2"
+
+[features]
+default = []
+# Integrated authentication (Kerberos / GSSAPI) on Linux/macOS. Mirrors
+# tiberius' `integrated-auth-gssapi` feature. Enables `AuthMethod::Integrated`.
+integrated-auth-gssapi = ["mssql-tds/gssapi"]
+# Integrated authentication (SSPI / NTLM / Kerberos) on Windows. Mirrors
+# tiberius' `winauth` feature. Enables `AuthMethod::Integrated`.
+winauth = ["mssql-tds/sspi"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,9 +18,9 @@
 //!    .trust_cert();
 //! ```
 
-use mssql_tds::connection::client_context::{
-    ClientContext, DriverVersion, TdsAuthenticationMethod,
-};
+#[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
+use mssql_tds::connection::client_context::{ClientContext, DriverVersion};
 use mssql_tds::core::EncryptionSetting;
 
 /// The driver name sent in the TDS Login7 packet and UserAgent feature extension.
@@ -56,6 +56,11 @@ pub enum AuthMethod {
     /// SQL Server authentication with username and password.
     SqlServer { user: String, password: String },
     /// Windows Integrated authentication (Kerberos/NTLM).
+    ///
+    /// Requires either the `integrated-auth-gssapi` feature (Linux/macOS,
+    /// pulls GSSAPI / Kerberos via `mssql-tds`) or the `winauth` feature
+    /// (Windows, pulls SSPI via `mssql-tds`).
+    #[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
     Integrated,
 }
 
@@ -69,6 +74,10 @@ impl AuthMethod {
     }
 
     /// Create Windows Integrated authentication.
+    ///
+    /// Requires the `integrated-auth-gssapi` (Linux/macOS) or `winauth`
+    /// (Windows) Cargo feature.
+    #[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
     pub fn integrated() -> Self {
         AuthMethod::Integrated
     }
@@ -205,6 +214,7 @@ impl Config {
                 ctx.user_name = user.clone();
                 ctx.password = password.clone();
             }
+            #[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
             AuthMethod::Integrated => {
                 ctx.tds_authentication_method = TdsAuthenticationMethod::SSPI;
             }
@@ -250,6 +260,7 @@ impl Default for Config {
 #[cfg(test)]
 mod tests {
     use crate::config::*;
+    #[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
     use mssql_tds::connection::client_context::TdsAuthenticationMethod;
 
     #[test]
@@ -286,6 +297,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "integrated-auth-gssapi", feature = "winauth"))]
     fn integrated_auth() {
         let mut cfg = Config::new();
         cfg.authentication(AuthMethod::integrated());


### PR DESCRIPTION
Closes #16.

Mirrors tiberius' `integrated-auth-gssapi` (Linux/macOS) and `winauth` (Windows) Cargo features. Without one enabled, the `Integrated` variant, the `AuthMethod::integrated()` constructor, and the SSPI dispatch arm are all removed at compile time. Default is no integrated auth, matching tiberius.

This lets crates that only use SQL or AAD authentication avoid pulling the GSSAPI/SSPI dependency tree (libgssapi-krb5 on Linux, etc.) — exactly the concern Windmill carries today via its target-conditional tiberius feature flags.

## Cargo features
| Bridge feature | Forwards to mssql-tds | Tiberius equivalent |
|---|---|---|
| `integrated-auth-gssapi` | `gssapi` | `integrated-auth-gssapi` |
| `winauth` | `sspi` | `winauth` |

## Verified
- `cargo build --tests` (no integrated-auth) → builds clean.
- `cargo build --tests --features integrated-auth-gssapi` → builds clean.
- `cargo test --lib` → 27 passed.
- `cargo test --lib --features integrated-auth-gssapi` → 28 passed (extra: `integrated_auth` unit test).

## Migration note
Callers currently writing `AuthMethod::integrated()` will fail to compile after this lands unless they enable one of the two features. Bridge consumers (e.g., Windmill) should mirror their existing tiberius target-conditional feature pattern:

```toml
[target.'cfg(target_os = "linux")'.dependencies]
mssql-tiberius-bridge = { version = "...", features = ["integrated-auth-gssapi"] }

[target.'cfg(target_os = "windows")'.dependencies]
mssql-tiberius-bridge = { version = "...", features = ["winauth"] }
```

Part of windmill migration umbrella #21.