### PR TITLE
feat(query): true wire-level row streaming + buffered into_row_stream (#20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,9 +734,12 @@ dependencies = [
 name = "mssql-tiberius-bridge"
 version = "0.1.0-preview.1"
 dependencies = [
+ "async-stream",
  "async-trait",
  "chrono",
  "deadpool",
+ "futures-core",
+ "futures-util",
  "mssql-tds-preview",
  "rust_decimal",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ tokio = { version = "1", features = ["net"] }
 serde_json = "1"
 async-trait = "0.1"
 thiserror = "2"
+futures-core = "0.3"
+async-stream = "0.3"
+
+[dev-dependencies]
+futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A tiberius-compatible API bridge over Microsoft's [`mssql-tds`](https://github.c
 
 - `row.get::<T, _>("column_name")` — named and indexed column access
 - `stream.into_first_result()` — collect results into `Vec<Row>`
+- `stream.into_row_stream()` — `Stream<Item = Result<Row>>` over a buffered `QueryResult` (rows pre-buffered)
+- `client.query_streamed(sql, params)` / `simple_query_streamed(sql)` — true wire-level row streaming for memory-bounded large result sets
 - `conn.query(sql, &[&param])` — positional `@P1, @P2` parameters
 - `Config::new().host().port().trust_cert()` — fluent builder
 - `Config::trust_cert_ca("ca.pem")` — pin a CA certificate (mirrors tiberius)

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,6 +89,7 @@ impl Client {
     /// Returns [`Error::Tds`] on SQL errors or connection issues.
     pub async fn simple_query(&mut self, sql: impl Into<String>) -> Result<QueryResult> {
         let sql = sql.into();
+        self.inner.close_query().await.map_err(Error::Tds)?;
         self.inner
             .execute(sql, None, None)
             .await
@@ -131,6 +132,7 @@ impl Client {
             return self.simple_query(sql).await;
         }
 
+        self.inner.close_query().await.map_err(Error::Tds)?;
         let rpc_params = build_params(params);
         self.inner
             .execute_sp_executesql(sql, rpc_params, None, None)
@@ -160,6 +162,7 @@ impl Client {
         params: &[&dyn ToSql],
     ) -> Result<ExecuteResult> {
         let sql = sql.into();
+        self.inner.close_query().await.map_err(Error::Tds)?;
 
         if params.is_empty() {
             self.inner
@@ -187,6 +190,94 @@ impl Client {
             }
         }
         Ok(ExecuteResult { counts })
+    }
+
+    /// Execute a parameterized query and return rows as a true wire-level
+    /// stream — each `.next().await` pulls the next row from the network
+    /// without buffering the rest of the result set.
+    ///
+    /// Mirrors tiberius' `Client::query(...).await?.into_row_stream()`
+    /// behavior; rows from multiple result sets are flattened in order.
+    ///
+    /// Use this for memory-bounded processing of large result sets
+    /// (e.g., the windmill MSSQL → S3 export path). For small result
+    /// sets, [`query`](Self::query) is more ergonomic.
+    ///
+    /// # Lifetime
+    ///
+    /// The returned stream borrows `&mut self` for its lifetime. You must
+    /// fully consume the stream (or drop it) before issuing another query
+    /// on the same `Client`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mssql_tiberius_bridge::Client;
+    /// use futures_util::StreamExt;
+    ///
+    /// # async fn ex(client: &mut Client) -> mssql_tiberius_bridge::Result<()> {
+    /// let mut s = client.query_streamed("SELECT @P1 AS n", &[&1i32]);
+    /// while let Some(row) = s.next().await {
+    ///     println!("{:?}", row?.get::<i32, _>("n"));
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn query_streamed<'a>(
+        &'a mut self,
+        sql: impl Into<String>,
+        params: &[&dyn ToSql],
+    ) -> std::pin::Pin<Box<dyn futures_core::Stream<Item = Result<crate::row::Row>> + Send + 'a>>
+    {
+        let sql = sql.into();
+        let rpc_params = if params.is_empty() {
+            None
+        } else {
+            Some(build_params(params))
+        };
+        Box::pin(async_stream::try_stream! {
+            // Drain any leftover state from a prior query / dropped stream
+            // so we don't hit "open batch" errors when re-using the Client.
+            self.inner.close_query().await.map_err(Error::Tds)?;
+
+            // Initiate the query inside the stream so the &mut self borrow
+            // lives for the entire row-pull duration.
+            match rpc_params {
+                None => self.inner.execute(sql, None, None).await.map_err(Error::Tds)?,
+                Some(p) => self.inner.execute_sp_executesql(sql, p, None, None).await.map_err(Error::Tds)?,
+            }
+
+            while let Some(metadata) = self
+                .inner
+                .get_current_resultset()
+                .map(|rs| rs.get_metadata().clone())
+            {
+                loop {
+                    let next = match self.inner.get_current_resultset() {
+                        Some(rs) => rs.next_row().await.map_err(Error::Tds)?,
+                        None => None,
+                    };
+                    match next {
+                        Some(values) => yield crate::row::Row::from_tds(&metadata, values),
+                        None => break,
+                    }
+                }
+                if !self.inner.move_to_next().await.map_err(Error::Tds)? {
+                    break;
+                }
+            }
+        })
+    }
+
+    /// Streaming counterpart of [`simple_query`](Self::simple_query) — see
+    /// [`query_streamed`](Self::query_streamed) for semantics and the
+    /// borrow contract.
+    pub fn simple_query_streamed<'a>(
+        &'a mut self,
+        sql: impl Into<String>,
+    ) -> std::pin::Pin<Box<dyn futures_core::Stream<Item = Result<crate::row::Row>> + Send + 'a>>
+    {
+        self.query_streamed(sql, &[])
     }
 
     /// Access the underlying `mssql-tds` [`TdsClient`] for advanced operations.

--- a/src/query.rs
+++ b/src/query.rs
@@ -77,12 +77,91 @@ impl QueryResult {
         self.result_sets.len()
     }
 
+    /// Consume into a [`Stream`](futures_core::Stream) of rows across all
+    /// result sets.
+    ///
+    /// Mirrors tiberius' `QueryStream::into_row_stream()` for API
+    /// compatibility. Use this when migrating code that calls
+    /// `.into_row_stream().map(...).next().await` (e.g., the
+    /// `windmill-worker` MSSQL S3 export path).
+    ///
+    /// # Limitations
+    ///
+    /// **Rows are pre-collected.** Unlike tiberius (which streams from the
+    /// wire), this yields rows that have already been buffered into memory
+    /// during the originating `query()` / `simple_query()` call. The
+    /// streaming API is preserved for migration ergonomics, but wire-level
+    /// streaming will require the `Client::query_streamed` follow-up
+    /// tracked in <https://github.com/saurabh500/mssql-tiberius-bridge/issues/20>.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mssql_tiberius_bridge::Client;
+    /// use futures_util::StreamExt;
+    ///
+    /// # async fn example(client: &mut Client) -> mssql_tiberius_bridge::Result<()> {
+    /// let mut stream = client
+    ///     .simple_query("SELECT 1 AS n UNION ALL SELECT 2")
+    ///     .await?
+    ///     .into_row_stream();
+    /// while let Some(row) = stream.next().await {
+    ///     let row = row?;
+    ///     println!("{:?}", row.get::<i32, _>("n"));
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_row_stream(self) -> RowStream {
+        let rows: Vec<Row> = self
+            .result_sets
+            .into_iter()
+            .flat_map(|(meta, rows)| {
+                rows.into_iter()
+                    .map(move |values| Row::from_tds(&meta, values))
+            })
+            .collect();
+        RowStream {
+            rows: rows.into_iter(),
+        }
+    }
+
     /// Create an empty QueryResult.
     #[allow(dead_code)]
     pub(crate) fn empty() -> Self {
         QueryResult {
             result_sets: Vec::new(),
         }
+    }
+}
+
+/// A `Stream` of [`Row`]s yielded across all result sets of a buffered
+/// [`QueryResult`].
+///
+/// Created by [`QueryResult::into_row_stream`]. Implements
+/// [`futures_core::Stream`] so it composes with `StreamExt`/`TryStreamExt`
+/// (`.map`, `.try_next`, `.collect`, etc.) — matching the API surface
+/// callers used with tiberius' `into_row_stream()`.
+///
+/// **Note:** rows are pre-buffered (see
+/// [`QueryResult::into_row_stream`] for the limitation and roadmap).
+pub struct RowStream {
+    rows: std::vec::IntoIter<Row>,
+}
+
+impl futures_core::Stream for RowStream {
+    type Item = crate::error::Result<Row>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::task::Poll::Ready(self.rows.next().map(Ok))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.rows.len();
+        (n, Some(n))
     }
 }
 

--- a/tests/row_stream.rs
+++ b/tests/row_stream.rs
@@ -1,0 +1,203 @@
+//! Integration tests for [`QueryResult::into_row_stream`].
+//!
+//! Mirrors tiberius' `into_row_stream_should_work` test from
+//! `tiberius/tests/query.rs`. Verifies the streaming API contract that
+//! windmill's S3 export path depends on (`.into_row_stream().map(...).next()`).
+
+use futures_util::StreamExt;
+use futures_util::TryStreamExt;
+use mssql_tiberius_bridge::{AuthMethod, Client, Config, Row};
+
+fn test_config() -> Config {
+    let password = match std::env::var("TEST_DB_PASSWORD") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("TEST_DB_PASSWORD not set, skipping");
+            std::process::exit(0);
+        }
+    };
+    let mut cfg = Config::new();
+    cfg.host(std::env::var("TEST_DB_HOST").unwrap_or("localhost".into()))
+        .port(
+            std::env::var("TEST_DB_PORT")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(1433),
+        )
+        .database(std::env::var("TEST_DB_NAME").unwrap_or("master".into()))
+        .authentication(AuthMethod::sql_server(
+            std::env::var("TEST_DB_USER").unwrap_or("sa".into()),
+            password,
+        ))
+        .trust_cert();
+    cfg
+}
+
+async fn connect() -> Client {
+    Client::connect(&test_config())
+        .await
+        .expect("connect to test SQL Server")
+}
+
+#[tokio::test]
+async fn into_row_stream_yields_all_rows() {
+    let mut client = connect().await;
+    let stream = client
+        .simple_query("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3")
+        .await
+        .unwrap()
+        .into_row_stream();
+
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].get::<i32, _>("n"), Some(1));
+    assert_eq!(rows[1].get::<i32, _>("n"), Some(2));
+    assert_eq!(rows[2].get::<i32, _>("n"), Some(3));
+}
+
+#[tokio::test]
+async fn into_row_stream_supports_map_next() {
+    // Mirrors the windmill S3 export pattern:
+    //   stream.map(|row| row_to_json(row?)).next().await
+    let mut client = connect().await;
+    let mut stream = client
+        .simple_query("SELECT 'hello' AS s UNION ALL SELECT 'world'")
+        .await
+        .unwrap()
+        .into_row_stream()
+        .map(|row| row.map(|r| r.get::<&str, _>("s").unwrap().to_string()));
+
+    let mut got = Vec::new();
+    while let Some(item) = stream.next().await {
+        got.push(item.unwrap());
+    }
+    assert_eq!(got, vec!["hello".to_string(), "world".to_string()]);
+}
+
+#[tokio::test]
+async fn into_row_stream_dropped_early_does_not_panic() {
+    // Mirrors tiberius'
+    // `drop_stream_before_handling_all_results_should_not_cause_weird_things`.
+    // Because the bridge buffers rows up-front, dropping the stream simply
+    // drops the in-memory Vec — no wire state to corrupt. The client must
+    // remain usable for subsequent queries.
+    let mut client = connect().await;
+    {
+        let mut stream = client
+            .simple_query("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3")
+            .await
+            .unwrap()
+            .into_row_stream();
+        // Pull only the first row, then drop.
+        let _ = stream.next().await;
+    }
+
+    // Client should still work for further queries.
+    let rows = client.simple_query("SELECT 42 AS n").await.unwrap();
+    let rows = rows.into_first_result();
+    assert_eq!(rows[0].get::<i32, _>("n"), Some(42));
+}
+
+#[tokio::test]
+async fn into_row_stream_empty_result_set() {
+    let mut client = connect().await;
+    let stream = client
+        .simple_query("SELECT 1 AS n WHERE 1 = 0")
+        .await
+        .unwrap()
+        .into_row_stream();
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 0);
+}
+
+#[tokio::test]
+async fn into_row_stream_flattens_multiple_result_sets() {
+    let mut client = connect().await;
+    let stream = client
+        .simple_query("SELECT 1 AS n; SELECT 2 AS n")
+        .await
+        .unwrap()
+        .into_row_stream();
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].get::<i32, _>("n"), Some(1));
+    assert_eq!(rows[1].get::<i32, _>("n"), Some(2));
+}
+
+// =============================================================================
+// True wire-level streaming: Client::query_streamed / simple_query_streamed
+// =============================================================================
+
+#[tokio::test]
+async fn query_streamed_yields_all_rows_in_order() {
+    let mut client = connect().await;
+    let stream = client.simple_query_streamed(
+        "SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4",
+    );
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 4);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row.get::<i32, _>("n"), Some(i as i32 + 1));
+    }
+}
+
+#[tokio::test]
+async fn query_streamed_with_params_roundtrips() {
+    let mut client = connect().await;
+    let stream = client.query_streamed("SELECT @P1 AS a, @P2 AS b", &[&7i32, &"hi"]);
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<i32, _>("a"), Some(7));
+    assert_eq!(rows[0].get::<&str, _>("b"), Some("hi"));
+}
+
+#[tokio::test]
+async fn query_streamed_empty_result_set() {
+    let mut client = connect().await;
+    let stream = client.simple_query_streamed("SELECT 1 AS n WHERE 1 = 0");
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn query_streamed_flattens_multiple_result_sets() {
+    let mut client = connect().await;
+    let stream = client.simple_query_streamed("SELECT 1 AS n; SELECT 2 AS n; SELECT 3 AS n");
+    let rows: Vec<Row> = stream.try_collect().await.unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].get::<i32, _>("n"), Some(1));
+    assert_eq!(rows[1].get::<i32, _>("n"), Some(2));
+    assert_eq!(rows[2].get::<i32, _>("n"), Some(3));
+}
+
+#[tokio::test]
+async fn query_streamed_pulls_lazily_one_at_a_time() {
+    // Pull only the first row, then drop. Because we yield row-by-row,
+    // the first .next() must not have to materialize all rows. We can't
+    // cheaply observe wire-level laziness directly, but we can verify
+    // partial consumption returns the right element ordering.
+    let mut client = connect().await;
+    {
+        let mut stream =
+            client.simple_query_streamed("SELECT 10 AS n UNION ALL SELECT 20 UNION ALL SELECT 30");
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.get::<i32, _>("n"), Some(10));
+        // Drop stream mid-result-set.
+    }
+    // Client must remain usable for a follow-up query (this exercises
+    // mssql-tds' state recovery when an unread result set is abandoned).
+    let rs = client.simple_query("SELECT 99 AS n").await.unwrap();
+    let rows = rs.into_first_result();
+    assert_eq!(rows[0].get::<i32, _>("n"), Some(99));
+}
+
+#[tokio::test]
+async fn query_streamed_supports_map_next() {
+    // Mirrors windmill's S3 export pattern.
+    let mut client = connect().await;
+    let stream = client
+        .simple_query_streamed("SELECT 'a' AS s UNION ALL SELECT 'b'")
+        .map(|row| row.map(|r| r.get::<&str, _>("s").unwrap().to_string()));
+    let got: Vec<String> = stream.try_collect().await.unwrap();
+    assert_eq!(got, vec!["a".to_string(), "b".to_string()]);
+}


### PR DESCRIPTION
Closes #20.

Adds **true wire-level streaming** via `Client::query_streamed` / `Client::simple_query_streamed`, which pull rows from `mssql-tds` row-by-row using `ResultSet::next_row`. Each `.next().await` makes one wire pull — large result sets are no longer bounded by available memory.

Also adds the buffered `QueryResult::into_row_stream()` shim for callers who already have a `QueryResult` and want a `Stream` interface.

## Why both?

| Method | Buffers? | Borrow | When to use |
|---|---|---|---|
| `client.query(...).await?.into_row_stream()` | Yes (full result set in memory) | none | Small result sets where you want `Stream` ergonomics |
| `client.query_streamed(sql, params)` | **No — true wire streaming** | `&mut Client` for stream lifetime | Large result sets, memory-bounded processing (windmill S3 export) |

The buffered path mirrors tiberius API surface exactly. The streamed path is the actual perf win — it's what windmill's MSSQL → S3 export needs.

## Implementation notes

- Returns `Pin<Box<dyn Stream + Send + 'a>>` because `async_stream::AsyncStream` is `!Unpin` and callers expect to use `StreamExt::next` etc.
- `simple_query` / `query` / `execute` / `query_streamed` now call `mssql_tds::TdsClient::close_query()` at entry. This drains any orphaned tokens from a previously dropped stream — essential for the "user pulls 1 row, drops the stream, issues a new query" pattern. Without this we hit `UsageError("There is an open batch on the current connection. It must be closed or fully consumed before executing another operation.")`.

## Tests (`tests/row_stream.rs`, 11 integration tests, all green on 10.0.0.21,1434)

**Buffered `QueryResult::into_row_stream`:**
- `into_row_stream_yields_all_rows`
- `into_row_stream_supports_map_next`
- `into_row_stream_dropped_early_does_not_panic`
- `into_row_stream_empty_result_set`
- `into_row_stream_flattens_multiple_result_sets`

**True wire streaming `Client::query_streamed`:**
- `query_streamed_yields_all_rows_in_order`
- `query_streamed_with_params_roundtrips`
- `query_streamed_empty_result_set`
- `query_streamed_flattens_multiple_result_sets`
- `query_streamed_pulls_lazily_one_at_a_time` — pulls 1 row, drops stream, issues new query (this is the test that revealed and now verifies the auto-drain fix)
- `query_streamed_supports_map_next` — windmill S3 export pattern

Total: 38 baseline + 11 stream + verified at 46 in tiberius_compat (PR #24 merged) = full green.

## Deps
- `futures-core = "0.3"` (`Stream` trait)
- `futures-util = "0.3"` as **dev-dep only**

Part of windmill migration umbrella #21.