### PR TITLE
docs: runtime dependencies for each AuthMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,46 @@ async fn main() -> mssql_tiberius_bridge::Result<()> {
 | `row.get::<&str, _>("col")` | `row.get::<&str, _>("col")` |
 | `tiberius::AuthMethod::sql_server` | `AuthMethod::sql_server` |
 
+## Runtime requirements
+
+The bridge itself is pure Rust. **No native libraries are linked at compile time**, so binaries build cleanly on minimal targets (alpine, distroless, scratch, musl). However, some authentication modes load system libraries at runtime via `dlopen` and require those libraries to be present on the host where the binary runs.
+
+### SQL authentication (`AuthMethod::sql_server`)
+
+No runtime dependencies beyond a working TCP stack. Works in any container.
+
+### AAD token authentication (`AuthMethod::aad_token`)
+
+No runtime dependencies on the bridge side — you supply the JWT yourself (typically via `azure_identity` or MSAL). Works in any container.
+
+### Integrated authentication (`AuthMethod::Integrated`) — Linux / macOS
+
+Uses Kerberos via `libgssapi_krb5`, loaded at **runtime** with `dlopen`. The library is **not** linked at build time; binaries build without it, but calling `Client::connect` with `Integrated` auth will fail at runtime if it's missing.
+
+| OS | Package | Library file searched |
+|---|---|---|
+| Debian / Ubuntu | `libgssapi-krb5-2` (usually preinstalled; install via `apt-get install libgssapi-krb5-2`) | `libgssapi_krb5.so.2` |
+| RHEL / Fedora / Rocky | `krb5-libs` | `libgssapi_krb5.so.2` |
+| Alpine | `krb5-libs` (`apk add krb5-libs`) | `libgssapi_krb5.so.2` |
+| Arch | `krb5` | `libgssapi_krb5.so.2` |
+| macOS | Bundled with the OS (Heimdal) | `libgssapi_krb5.dylib` / `/System/Library/Frameworks/GSS.framework` |
+
+**Distroless / scratch images:** must add the libgssapi-krb5 shared object explicitly, or use a base image that includes it. `gcr.io/distroless/cc-debian12` does **not** include it.
+
+In addition to the library, integrated auth needs:
+
+- A valid Kerberos ticket-granting ticket. Run `kinit user@REALM` (or use a keytab) before connecting.
+- A correctly configured `/etc/krb5.conf` pointing at your KDC.
+- Network reachability to the KDC (typically port 88) and a SPN registered for the SQL Server service principal.
+
+### Integrated authentication (`AuthMethod::Integrated`) — Windows
+
+Uses SSPI via `secur32.dll`, which is part of every supported Windows install. **No extra packages required.** The Windows account running the process must be a domain account (or have cached domain credentials) for Kerberos/NTLM to succeed.
+
+### TLS
+
+`mssql-tds` uses `native-tls`, which on Linux requires OpenSSL at runtime (already a dep of nearly every Linux distro and most container base images). Alpine needs `apk add openssl ca-certificates`.
+
 ## License
 
 MIT


### PR DESCRIPTION
Adds a **Runtime requirements** section to the README.

## Why

The bridge links no native libs at compile time, so binaries build cleanly on minimal targets (alpine, musl, distroless). But `AuthMethod::Integrated` on Linux uses `dlopen("libgssapi_krb5.so", RTLD_LAZY)` at runtime — meaning the user gets a build-fine, run-fail experience if their container doesn't ship libgssapi-krb5. Today there's no doc telling them what to install.

This PR documents per-`AuthMethod` runtime requirements:

| AuthMethod | Linux/macOS extra deps | Windows extra deps |
|---|---|---|
| `sql_server` | none | none |
| `aad_token` | none | none |
| `Integrated` | `libgssapi_krb5` + `kinit` + `/etc/krb5.conf` | none (system `secur32.dll`) |

Plus a TLS note (native-tls → OpenSSL on Linux).

Includes a per-distro package table (Debian/Ubuntu, RHEL, Alpine, Arch) and an explicit callout that `gcr.io/distroless/cc-debian12` does NOT ship libgssapi-krb5.

Pure docs change — no code, no test impact.