### PR TITLE
perf(row): share per-result-set schema via Arc<RowSchema>

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -247,10 +247,10 @@ impl Client {
                 Some(p) => self.inner.execute_sp_executesql(sql, p, None, None).await.map_err(Error::Tds)?,
             }
 
-            while let Some(metadata) = self
+            while let Some(schema) = self
                 .inner
                 .get_current_resultset()
-                .map(|rs| rs.get_metadata().clone())
+                .map(|rs| crate::row::RowSchema::from_metadata(rs.get_metadata()))
             {
                 loop {
                     let next = match self.inner.get_current_resultset() {
@@ -258,7 +258,9 @@ impl Client {
                         None => None,
                     };
                     match next {
-                        Some(values) => yield crate::row::Row::from_tds(&metadata, values),
+                        Some(values) => {
+                            yield crate::row::Row::from_schema(schema.clone(), values)
+                        }
                         None => break,
                     }
                 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -53,8 +53,9 @@ impl QueryResult {
             return Vec::new();
         }
         let (meta, rows) = sets.remove(0);
+        let schema = crate::row::RowSchema::from_metadata(&meta);
         rows.into_iter()
-            .map(|values| Row::from_tds(&meta, values))
+            .map(|values| Row::from_schema(schema.clone(), values))
             .collect()
     }
 
@@ -65,8 +66,9 @@ impl QueryResult {
         self.result_sets
             .into_iter()
             .map(|(meta, rows)| {
+                let schema = crate::row::RowSchema::from_metadata(&meta);
                 rows.into_iter()
-                    .map(|values| Row::from_tds(&meta, values))
+                    .map(|values| Row::from_schema(schema.clone(), values))
                     .collect()
             })
             .collect()
@@ -117,8 +119,9 @@ impl QueryResult {
             .result_sets
             .into_iter()
             .flat_map(|(meta, rows)| {
+                let schema = crate::row::RowSchema::from_metadata(&meta);
                 rows.into_iter()
-                    .map(move |values| Row::from_tds(&meta, values))
+                    .map(move |values| Row::from_schema(schema.clone(), values))
             })
             .collect();
         RowStream {

--- a/src/row.rs
+++ b/src/row.rs
@@ -4,6 +4,7 @@
 //! and provides typed access to column values via [`get()`](Row::get).
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::query::metadata::ColumnMetadata;
@@ -11,29 +12,48 @@ use mssql_tds::query::metadata::ColumnMetadata;
 use crate::column::Column;
 use crate::error::{Error, Result};
 
-/// A single result row with tiberius-style typed column access.
+/// Per-result-set schema (column metadata + name index).
 ///
-/// String values are eagerly decoded from UTF-16 to UTF-8 at construction
-/// time, enabling `row.get::<&str, _>("col")` without allocation.
-#[derive(Debug, Clone)]
-pub struct Row {
-    columns: Vec<Column>,
-    values: Vec<ColumnValues>,
-    /// Pre-decoded UTF-8 strings for &str borrowing support.
-    decoded_strings: Vec<Option<String>>,
-    name_map: HashMap<String, usize>,
+/// Built once per result set and shared across every [`Row`] in that set
+/// via [`Arc`], so streaming N rows from a result set with K columns no
+/// longer pays the O(K) `Vec<Column>` + `HashMap<String, usize>` build
+/// cost per row.
+#[derive(Debug)]
+pub struct RowSchema {
+    pub(crate) columns: Vec<Column>,
+    pub(crate) name_map: HashMap<String, usize>,
 }
 
-impl Row {
-    /// Build a Row from mssql-tds column metadata and decoded values.
-    pub fn from_tds(metadata: &[ColumnMetadata], values: Vec<ColumnValues>) -> Self {
+impl RowSchema {
+    /// Build a schema from a slice of mssql-tds column metadata.
+    pub fn from_metadata(metadata: &[ColumnMetadata]) -> Arc<Self> {
         let columns: Vec<Column> = metadata.iter().map(Column::from_tds).collect();
         let name_map: HashMap<String, usize> = columns
             .iter()
             .enumerate()
             .map(|(i, c)| (c.name.clone(), i))
             .collect();
-        // Pre-decode strings so &str can be borrowed from the Row.
+        Arc::new(RowSchema { columns, name_map })
+    }
+}
+
+/// A single result row with tiberius-style typed column access.
+///
+/// String values are eagerly decoded from UTF-16 to UTF-8 at construction
+/// time, enabling `row.get::<&str, _>("col")` without allocation.
+#[derive(Debug, Clone)]
+pub struct Row {
+    schema: Arc<RowSchema>,
+    values: Vec<ColumnValues>,
+    /// Pre-decoded UTF-8 strings for &str borrowing support.
+    decoded_strings: Vec<Option<String>>,
+}
+
+impl Row {
+    /// Build a Row reusing a pre-built [`RowSchema`]. Hot path for the
+    /// streaming and buffered code paths — clones the `Arc`, never the
+    /// underlying `Vec<Column>`/`HashMap`.
+    pub fn from_schema(schema: Arc<RowSchema>, values: Vec<ColumnValues>) -> Self {
         let decoded_strings: Vec<Option<String>> = values
             .iter()
             .map(|v| match v {
@@ -44,16 +64,24 @@ impl Row {
             })
             .collect();
         Row {
-            columns,
+            schema,
             values,
             decoded_strings,
-            name_map,
         }
+    }
+
+    /// Build a Row from mssql-tds column metadata and decoded values.
+    ///
+    /// Convenience wrapper that builds a fresh [`RowSchema`] each call —
+    /// prefer [`Row::from_schema`] inside row loops where the schema is
+    /// known to be constant for the result set.
+    pub fn from_tds(metadata: &[ColumnMetadata], values: Vec<ColumnValues>) -> Self {
+        Self::from_schema(RowSchema::from_metadata(metadata), values)
     }
 
     /// Column metadata for this row.
     pub fn columns(&self) -> &[Column] {
-        &self.columns
+        &self.schema.columns
     }
 
     /// Number of columns.
@@ -95,7 +123,7 @@ impl Row {
 
     /// Look up a column index by name (case-sensitive).
     pub fn column_index(&self, name: &str) -> Option<usize> {
-        self.name_map.get(name).copied()
+        self.schema.name_map.get(name).copied()
     }
 }
 
@@ -122,7 +150,8 @@ impl ColumnIndex for usize {
 
 impl ColumnIndex for &str {
     fn resolve(&self, row: &Row) -> Result<usize> {
-        row.name_map
+        row.schema
+            .name_map
             .get(*self)
             .copied()
             .ok_or_else(|| Error::ColumnNotFound(self.to_string()))
@@ -416,19 +445,8 @@ mod tests {
             .enumerate()
             .map(|(i, c)| (c.name.clone(), i))
             .collect();
-        let decoded_strings: Vec<Option<String>> = values
-            .iter()
-            .map(|v| match v {
-                ColumnValues::String(s) => Some(s.to_utf8_string()),
-                _ => None,
-            })
-            .collect();
-        Row {
-            columns,
-            values,
-            decoded_strings,
-            name_map,
-        }
+        let schema = Arc::new(RowSchema { columns, name_map });
+        Row::from_schema(schema, values)
     }
 
     #[test]


### PR DESCRIPTION
perf(row): share per-result-set schema via Arc<RowSchema>

Avoids rebuilding column metadata vector and name HashMap per row.

## Before
Row::from_tds(&metadata, values) ran per row, allocating a fresh
Vec<Column> + HashMap<String,usize> each time. O(N*K) work + N
duplicate metadata copies — compounds in the new wire-streamed
Client::query_streamed path.

## After
- New RowSchema { columns, name_map } built once per result set as
  Arc<RowSchema>.
- Row now holds Arc<RowSchema>.
- New Row::from_schema(Arc<RowSchema>, Vec<ColumnValues>) is the hot
  path — clones the Arc, pre-decodes row strings.
- Row::from_tds preserved as a convenience wrapper.

## Hot paths updated
- Client::query_streamed (wire streaming)
- QueryResult::into_first_result / into_results / into_row_stream

## Tests
46 + 11 stream tests still green against 10.0.0.21,1434.

Follow-up to #29.
