### PR TITLE
feat(lib): re-export DecimalParts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,3 +97,6 @@ pub use mssql_tds::connection::tds_client::TdsClient;
 /// Raw column values from mssql-tds, exposed for low-level access
 /// via [`Row::raw_value()`].
 pub use mssql_tds::datatypes::column_values::ColumnValues;
+/// Decimal/Numeric value representation from mssql-tds.
+/// Returned inside `ColumnValues::Decimal` and `ColumnValues::Numeric`.
+pub use mssql_tds::datatypes::decoder::DecimalParts;


### PR DESCRIPTION
Re-export `DecimalParts` from `mssql_tds::datatypes::decoder` so downstream
crates iterating `ColumnValues::Decimal` / `ColumnValues::Numeric` don't
need a direct dep on `mssql-tds-preview` just to name the inner type.

Discovered while migrating windmill's MSSQL executor — without this
re-export the executor had to do `use mssql_tds::datatypes::decoder::DecimalParts;`
which forces every consumer to add `mssql-tds-preview` as a direct dep.
