### PR TITLE
chore: bump version to 0.1.0-preview.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tiberius-bridge"
-version = "0.1.0-preview.1"
+version = "0.1.0-preview.2"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-tiberius-bridge"
-version = "0.1.0-preview.1"
+version = "0.1.0-preview.2"
 edition = "2021"
 description = "A tiberius-compatible API bridge over Microsoft's mssql-tds crate. Migrate from tiberius with minimal code changes."
 repository = "https://github.com/saurabh500/mssql-tiberius-bridge"


### PR DESCRIPTION
Bump bridge crate version from `0.1.0-preview.1` → `0.1.0-preview.2`.

Bundles all features merged since preview.1:

| PR | Change |
|----|--------|
| #22 | `Config::trust_cert_ca` for CA pinning |
| #23 | `ToSql` for `Vec<u8>`/`&[u8]` and chrono date/time types |
| #24 | `Config::readonly()` (ApplicationIntent=ReadOnly) |
| #26 | `AuthMethod::aad_token` for Entra ID federated auth |
| #27 | SSRP instance lookup auto-trigger when `instance_name` is set |
| #29 | `QueryResult::into_row_stream` for streaming API compat |
| #30 | Runtime dependency docs per `AuthMethod` |
| #31 | `Arc<RowSchema>` perf — share metadata across rows |

No API breakages — all additive.

Note: there's still PR #32 (re-export `DecimalParts`) open. If desired, land that first and roll into this same preview.2; otherwise it'll be in preview.3.
