### PR TITLE
chore(ci): add release-plz for automated releases + changelog

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,64 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  # Opens (or updates) a "Release PR" that bumps the version in Cargo.toml
+  # and regenerates CHANGELOG.md from conventional commits since the last release.
+  # Merge the PR to cut a release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'saurabh500'
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # When a Release PR merges (Cargo.toml version bump lands on main),
+  # this job tags the release and creates the GitHub Release with notes.
+  # Crates.io publish is intentionally left to the existing publish.yml
+  # workflow (manual `workflow_dispatch`) until the pipeline is trusted
+  # end-to-end. To enable auto-publish, flip `publish = true` in release-plz.toml
+  # and add CARGO_REGISTRY_TOKEN to this job's env.
+  release-plz-release:
+    name: Release-plz tag + GH release
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'saurabh500'
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release)
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file is maintained by [release-plz](https://release-plz.dev/) — entries
+are generated from [Conventional Commits](https://www.conventionalcommits.org/)
+when the Release PR is opened.
+
+## [Unreleased]
+
+## [0.1.0-preview.2] - 2026-05-09
+
+### Added
+- *(config)* `Config::trust_cert_ca` for CA pinning ([#22](https://github.com/saurabh500/mssql-tiberius-bridge/pull/22))
+- *(query)* `ToSql` for `Vec<u8>`, `&[u8]`, and chrono date/time types ([#23](https://github.com/saurabh500/mssql-tiberius-bridge/pull/23))
+- *(config)* `Config::readonly()` for `ApplicationIntent=ReadOnly` ([#24](https://github.com/saurabh500/mssql-tiberius-bridge/pull/24))
+- *(auth)* `AuthMethod::aad_token` for Entra ID federated auth ([#26](https://github.com/saurabh500/mssql-tiberius-bridge/pull/26))
+- *(config)* SSRP instance lookup auto-trigger when `instance_name` is set ([#27](https://github.com/saurabh500/mssql-tiberius-bridge/pull/27))
+- *(query)* `QueryResult::into_row_stream` for streaming API compatibility ([#29](https://github.com/saurabh500/mssql-tiberius-bridge/pull/29))
+- *(lib)* Re-export `DecimalParts` from `mssql_tds` ([#32](https://github.com/saurabh500/mssql-tiberius-bridge/pull/32))
+
+### Fixed
+- *(config)* Drop port from datasource when `instance_name` is set
+
+### Performance
+- *(row)* Share per-result-set schema via `Arc<RowSchema>` ([#31](https://github.com/saurabh500/mssql-tiberius-bridge/pull/31))
+
+### Documentation
+- Document runtime dependencies for each `AuthMethod` ([#30](https://github.com/saurabh500/mssql-tiberius-bridge/pull/30))
+
+## [0.1.0-preview.1] - 2026-04-17
+
+Initial public preview.
+
+### Added
+- Tiberius-compatible API surface (`Client`, `Config`, `AuthMethod`, `Row`, `QueryResult`, `ToSql`, `FromSql`).
+- `AuthMethod::sql_server` and `AuthMethod::integrated` (Kerberos/NTLM via Windows SSPI / Linux GSSAPI dlopen).
+- Connection pooling via `deadpool` (`Pool`, `PooledConnection`, `TdsManager`).
+- TLS via `native-tls` with `EncryptionLevel::Off | On | Required` and `trust_cert`.
+- Azure SQL routing redirects (auto-handled by `mssql-tds`, no manual reconnect needed).
+- JSON and Vector column type support (closes #3).
+- Pre-decoded string cache enabling `&str` borrowing from `Row`.
+- Unique UserAgent identity in TDS Login7 packet.
+- Code coverage via `cargo-llvm-cov` + Codecov upload.
+- Comprehensive tiberius-compatibility test suite + API documentation.
+- Publish workflow for crates.io.
+
+### Fixed
+- IntN/FltN/MoneyN column type resolution using wire byte length.
+- Time decode: `time_nanoseconds` is in 100ns units, not nanoseconds.
+
+### Changed
+- *(refactor)* Expose `Column` fields via getter methods instead of `pub`.
+
+[Unreleased]: https://github.com/saurabh500/mssql-tiberius-bridge/compare/v0.1.0-preview.2...HEAD
+[0.1.0-preview.2]: https://github.com/saurabh500/mssql-tiberius-bridge/compare/v0.1.0-preview.1...v0.1.0-preview.2
+[0.1.0-preview.1]: https://github.com/saurabh500/mssql-tiberius-bridge/releases/tag/v0.1.0-preview.1

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,52 @@
+[workspace]
+# Changelog: Keep-a-Changelog format, generated from conventional commits.
+changelog_update = true
+# Don't auto-publish from release-plz workflow; publish.yml stays the gate.
+# Set to true once you trust the pipeline end-to-end.
+publish = false
+# Auto-create a GitHub Release with notes when the Release PR merges.
+git_release_enable = true
+git_release_type = "auto"
+# Group commits by Conventional Commit type in CHANGELOG.md.
+git_tag_enable = true
+
+[changelog]
+# Keep-a-Changelog style with section grouping by commit type.
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+## [{{ version }}]{% if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+    {% if commit.breaking %}[**breaking**] {% endif %}\
+    {{ commit.message | upper_first }}\
+    {% if commit.links %} ({% for link in commit.links %}[{{ link.text }}]({{ link.href }}){% if not loop.last %}, {% endif %}{% endfor %}){% endif %}\
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Tests" },
+    { message = "^chore\\(deps\\)", group = "Dependencies" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^style", skip = true },
+    { body = ".*security", group = "Security" },
+]
+link_parsers = [
+    { pattern = "#(\\d+)", href = "https://github.com/saurabh500/mssql-tiberius-bridge/issues/$1", text = "#$1" },
+]


### PR DESCRIPTION
Adopt [release-plz](https://release-plz.dev/) so future releases are driven by Conventional Commits — no more manual version-bump PRs like #33.

## How it works after this lands

1. You merge feature/fix PRs to `main` using Conventional Commit messages (`feat:`, `fix:`, `perf:`, etc.) — already the established convention.
2. The `release-plz-pr` workflow opens a **"Release PR"** that:
   - Bumps the `version` in `Cargo.toml` (semver-aware: `feat` → minor, `fix` → patch, `!` → major).
   - Appends a Keep-a-Changelog section to `CHANGELOG.md` with all commits since the last tag, grouped by type and linked to PRs/issues.
3. You review the Release PR. Edit the changelog if you want to reword anything.
4. On merge, the `release-plz-release` workflow tags `vX.Y.Z` and creates a **GitHub Release** with the notes.

## What's intentionally NOT automated

Crates.io publishing stays with the existing manual `publish.yml` (`workflow_dispatch`) for now — `publish = false` in `release-plz.toml`. Once you trust the pipeline, flip to `true` and add `CARGO_REGISTRY_TOKEN` to the release-plz job env to fully automate.

## Files

- `release-plz.toml` — config: Keep-a-Changelog format, conventional-commit groupers, PR/issue auto-linking.
- `.github/workflows/release-plz.yml` — two jobs (`release-pr` on every push to main; `release` for tag/GH-release on Release-PR merge).
- `CHANGELOG.md` — bootstrap with handcrafted entries for `0.1.0-preview.1` and `0.1.0-preview.2` so the file isn't empty when the first auto-release runs.

## Permissions needed

The default `GITHUB_TOKEN` is sufficient for opening PRs and creating releases (`pull-requests: write`, `contents: write` are declared in the workflow). No new secrets.

## Order of operations recommendation

Land #33 (preview.2 bump) first, **then** land this. The first auto Release PR will then start from preview.3 with whatever's accumulated.
