### PR TITLE
chore(ci): add workflow_dispatch trigger to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Allow manual re-trigger from the Actions tab (useful if a run fails
+  # or the repo permissions for GITHUB_TOKEN change).
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Add `workflow_dispatch` to the release-plz workflow so it can be re-triggered manually from the Actions tab.

**Context**: the first release-plz run failed with `403 Forbidden — GitHub Actions is not permitted to create or approve pull requests`. Fix was setting `can_approve_pull_request_reviews=true` on the repo's Actions permissions (Settings → Actions → General → Workflow permissions). After that, a manual re-run succeeded and created the v0.1.0-preview.2 GitHub Release. This PR makes such re-runs one-click in the future.
