### PR TITLE
feat: Client::ping() liveness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A tiberius-compatible API bridge over Microsoft's [`mssql-tds`](https://github.c
 - `stream.into_first_result()` — collect results into `Vec<Row>`
 - `stream.into_row_stream()` — `Stream<Item = Result<Row>>` over a buffered `QueryResult` (rows pre-buffered)
 - `client.query_streamed(sql, params)` / `simple_query_streamed(sql)` — true wire-level row streaming for memory-bounded large result sets
+- `client.ping()` — lightweight liveness check for connection pools
 - `conn.query(sql, &[&param])` — positional `@P1, @P2` parameters
 - `Config::new().host().port().trust_cert()` — fluent builder
 - `Config::trust_cert_ca("ca.pem")` — pin a CA certificate (mirrors tiberius)
@@ -56,6 +57,7 @@ async fn main() -> mssql_tiberius_bridge::Result<()> {
 | `Client::connect(config, tcp)` | `Client::connect(&config)` (handles TCP internally) |
 | `conn.simple_query(sql)` | `client.simple_query(sql)` |
 | `conn.query(sql, &[&p1])` | `client.query(sql, &[&p1])` |
+| connection-pool validation | `client.ping()` |
 | `stream.into_first_result()` | `.into_first_result()` |
 | `row.get::<&str, _>("col")` | `row.get::<&str, _>("col")` |
 | `tiberius::AuthMethod::sql_server` | `AuthMethod::sql_server` |

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,6 +60,20 @@ impl Client {
         Ok(Client { inner: client })
     }
 
+    /// Check whether the connection is alive and responsive.
+    ///
+    /// This sends a tiny `SELECT 1` batch and drains the result so the client is
+    /// ready for the next request. Connection pools can use this as a cheap
+    /// validation step before handing out an existing connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Tds`] if the batch fails or the connection cannot be used.
+    pub async fn ping(&mut self) -> Result<()> {
+        let _ = self.simple_query("SELECT 1").await?.into_first_result();
+        Ok(())
+    }
+
     /// Execute a raw SQL query without parameters.
     ///
     /// Mirrors tiberius' `simple_query`. The SQL is sent as a TDS SQL Batch
@@ -322,5 +336,11 @@ mod tests {
         let mut cfg = Config::new();
         cfg.host("myserver").port(1433).database("testdb");
         assert_eq!(cfg.datasource_string(), "tcp:myserver,1433");
+    }
+
+    #[test]
+    fn client_is_send_for_pooling() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Client>();
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -16,10 +16,9 @@
 
 use deadpool::managed::{Manager, Metrics, RecycleError, RecycleResult};
 
-use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient, TdsClient};
-use mssql_tds::connection_provider::tds_connection_provider::TdsConnectionProvider;
-
+use crate::client::Client;
 use crate::config::Config;
+use crate::error::Error;
 
 /// A checked-out connection from the pool.
 pub type PooledConnection = deadpool::managed::Object<TdsManager>;
@@ -29,7 +28,7 @@ pub type Pool = deadpool::managed::Pool<TdsManager>;
 
 /// [`deadpool::managed::Manager`] implementation for mssql-tds connections.
 ///
-/// Creates and recycles `TdsClient` connections using the provided [`Config`].
+/// Creates and recycles [`Client`] connections using the provided [`Config`].
 #[derive(Debug, Clone)]
 pub struct TdsManager {
     config: Config,
@@ -56,35 +55,15 @@ impl TdsManager {
 }
 
 impl Manager for TdsManager {
-    type Type = TdsClient;
-    type Error = mssql_tds::error::Error;
+    type Type = Client;
+    type Error = Error;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let ctx = self.config.to_client_context();
-        let datasource = self.config.datasource_string();
-        let provider = TdsConnectionProvider {};
-        provider.create_client(ctx, &datasource, None).await
+        Client::connect(&self.config).await
     }
 
     async fn recycle(&self, conn: &mut Self::Type, _: &Metrics) -> RecycleResult<Self::Error> {
-        // Cheap ping to verify the connection is alive.
-        conn.execute("SELECT 1".to_string(), None, None)
-            .await
-            .map_err(RecycleError::Backend)?;
-
-        // Drain the result to reset state.
-        if let Some(rs) = conn.get_current_resultset() {
-            while rs
-                .next_row()
-                .await
-                .map_err(RecycleError::Backend)?
-                .is_some()
-            {}
-        }
-        // Move past any remaining result sets.
-        while conn.move_to_next().await.map_err(RecycleError::Backend)? {}
-
-        Ok(())
+        conn.ping().await.map_err(RecycleError::Backend)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -185,22 +185,57 @@ async fn decimal_type() {
 }
 
 #[tokio::test]
+async fn client_ping() {
+    let cfg = test_config();
+    let mut client = Client::connect(&cfg).await.expect("connect failed");
+
+    client.ping().await.expect("ping failed");
+
+    let rows = client
+        .simple_query("SELECT 1 AS value")
+        .await
+        .expect("query after ping failed")
+        .into_first_result();
+    assert_eq!(rows[0].get::<i32, _>("value"), Some(1));
+}
+
+#[tokio::test]
+#[ignore = "requires SQL Server reachable at 10.0.0.21:1434 and TEST_DB_PASSWORD"]
+async fn client_ping_against_known_sql_server() {
+    let password = match std::env::var("TEST_DB_PASSWORD") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("TEST_DB_PASSWORD not set, skipping");
+            return;
+        }
+    };
+    let mut cfg = Config::new();
+    cfg.host("10.0.0.21")
+        .port(1434)
+        .database("master")
+        .authentication(AuthMethod::sql_server(
+            std::env::var("TEST_DB_USER").unwrap_or("sa".into()),
+            password,
+        ))
+        .trust_cert();
+
+    let mut client = Client::connect(&cfg).await.expect("connect failed");
+    client.ping().await.expect("ping failed");
+}
+
+#[tokio::test]
 async fn connection_pool() {
     let cfg = test_config();
     let pool = TdsManager::create_pool(cfg, 4).expect("pool creation failed");
 
     let mut conn = pool.get().await.expect("pool checkout failed");
 
-    // Use raw TdsClient API through the pool
-    use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient};
-    conn.execute("SELECT 1".into(), None, None)
+    let rows = conn
+        .simple_query("SELECT 1 AS value")
         .await
-        .expect("execute failed");
-
-    if let Some(rs) = conn.get_current_resultset() {
-        let row = rs.next_row().await.expect("next_row failed");
-        assert!(row.is_some());
-    }
+        .expect("query failed")
+        .into_first_result();
+    assert_eq!(rows[0].get::<i32, _>("value"), Some(1));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #44. Mirrors tiberius#198, #299, #301.

## Summary
- Adds `Client::ping()` using a tiny `SELECT 1` batch and drains results.
- Refactors deadpool recycle validation to call `Client::ping()`.
- Adds docs plus live/ignored integration coverage.

## Validation
- `cargo check`
- `cargo test --lib`

## sp_reset_connection
Not feasible in the bridge today: `mssql-tds` exposes TDS reset packet flags only internally (`pub(crate)`) and has no public API for setting `RESET_CONNECTION` on the next packet.