### PR TITLE
Add config support for Login7 host, TLS override, and string encoding

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use mssql_tds::query::metadata::ColumnMetadata;
 
 use crate::config::Config;
 use crate::error::{Error, Result};
-use crate::query::{build_params, ExecuteResult, QueryResult, ToSql};
+use crate::query::{build_params_with_string_encoding, ExecuteResult, QueryResult, ToSql};
 
 /// An async SQL Server client with tiberius-style query methods.
 ///
@@ -36,6 +36,7 @@ use crate::query::{build_params, ExecuteResult, QueryResult, ToSql};
 /// ```
 pub struct Client {
     inner: TdsClient,
+    send_string_parameters_as_unicode: bool,
 }
 
 impl Client {
@@ -57,7 +58,10 @@ impl Client {
             .create_client(ctx, &datasource, None)
             .await
             .map_err(Error::Tds)?;
-        Ok(Client { inner: client })
+        Ok(Client {
+            inner: client,
+            send_string_parameters_as_unicode: config.string_parameters_as_unicode(),
+        })
     }
 
     /// Execute a raw SQL query without parameters.
@@ -133,7 +137,8 @@ impl Client {
         }
 
         self.inner.close_query().await.map_err(Error::Tds)?;
-        let rpc_params = build_params(params);
+        let rpc_params =
+            build_params_with_string_encoding(params, self.send_string_parameters_as_unicode);
         self.inner
             .execute_sp_executesql(sql, rpc_params, None, None)
             .await
@@ -170,7 +175,8 @@ impl Client {
                 .await
                 .map_err(Error::Tds)?;
         } else {
-            let rpc_params = build_params(params);
+            let rpc_params =
+                build_params_with_string_encoding(params, self.send_string_parameters_as_unicode);
             self.inner
                 .execute_sp_executesql(sql, rpc_params, None, None)
                 .await
@@ -233,7 +239,10 @@ impl Client {
         let rpc_params = if params.is_empty() {
             None
         } else {
-            Some(build_params(params))
+            Some(build_params_with_string_encoding(
+                params,
+                self.send_string_parameters_as_unicode,
+            ))
         };
         Box::pin(async_stream::try_stream! {
             // Drain any leftover state from a prior query / dropped stream

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,10 +108,13 @@ pub struct Config {
     auth: AuthMethod,
     trust_cert: bool,
     server_certificate: Option<String>,
+    host_name_in_certificate: Option<String>,
     readonly: bool,
     encryption: EncryptionLevel,
     application_name: Option<String>,
     instance_name: Option<String>,
+    client_name: Option<String>,
+    send_string_parameters_as_unicode: bool,
 }
 
 impl Config {
@@ -127,10 +130,13 @@ impl Config {
             },
             trust_cert: false,
             server_certificate: None,
+            host_name_in_certificate: None,
             readonly: false,
             encryption: EncryptionLevel::On,
             application_name: None,
             instance_name: None,
+            client_name: None,
+            send_string_parameters_as_unicode: true,
         }
     }
 
@@ -189,6 +195,30 @@ impl Config {
     pub fn trust_cert_ca(&mut self, path: impl Into<String>) -> &mut Self {
         self.server_certificate = Some(path.into());
         self
+    }
+
+    /// Override the hostname used for TLS certificate name validation.
+    pub fn host_name_in_certificate(&mut self, name: impl Into<String>) -> &mut Self {
+        self.host_name_in_certificate = Some(name.into());
+        self
+    }
+
+    /// Set the client workstation name sent in the Login7 packet.
+    pub fn client_name(&mut self, name: impl Into<String>) -> &mut Self {
+        self.client_name = Some(name.into());
+        self
+    }
+
+    /// Controls whether `&str` and `String` parameters are sent as NVARCHAR.
+    ///
+    /// Defaults to `true`. Set to `false` to send string parameters as VARCHAR.
+    pub fn send_string_parameters_as_unicode(&mut self, enabled: bool) -> &mut Self {
+        self.send_string_parameters_as_unicode = enabled;
+        self
+    }
+
+    pub(crate) fn string_parameters_as_unicode(&self) -> bool {
+        self.send_string_parameters_as_unicode
     }
 
     /// Send `ApplicationIntent=ReadOnly` in the login (mirrors tiberius'
@@ -275,6 +305,7 @@ impl Config {
 
         ctx.encryption_options.trust_server_certificate = self.trust_cert;
         ctx.encryption_options.server_certificate = self.server_certificate.clone();
+        ctx.encryption_options.host_name_in_cert = self.host_name_in_certificate.clone();
 
         match self.encryption {
             EncryptionLevel::Off => ctx.encryption_options.mode = EncryptionSetting::PreferOff,
@@ -288,6 +319,10 @@ impl Config {
 
         if let Some(ref app) = self.application_name {
             ctx.application_name = app.clone();
+        }
+
+        if let Some(ref client_name) = self.client_name {
+            ctx.workstation_id = client_name.clone();
         }
 
         // ── Driver identity ──
@@ -445,5 +480,42 @@ mod tests {
         // UserAgent feature extension fields
         assert_eq!(ctx.user_agent.library_name, "MS-TIB-BRID");
         assert_eq!(ctx.user_agent.driver_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn client_name_sets_workstation_id() {
+        let mut cfg = Config::new();
+        cfg.client_name("app-host-01");
+        assert_eq!(cfg.to_client_context().workstation_id, "app-host-01");
+    }
+
+    #[test]
+    fn default_client_name_comes_from_mssql_tds() {
+        let cfg = Config::new();
+        assert_eq!(
+            cfg.to_client_context().workstation_id,
+            ClientContext::default().workstation_id
+        );
+    }
+
+    #[test]
+    fn host_name_in_certificate_sets_tls_override() {
+        let mut cfg = Config::new();
+        cfg.host_name_in_certificate("sql.example.com");
+        assert_eq!(
+            cfg.to_client_context()
+                .encryption_options
+                .host_name_in_cert
+                .as_deref(),
+            Some("sql.example.com")
+        );
+    }
+
+    #[test]
+    fn send_string_parameters_as_unicode_defaults_to_true() {
+        let mut cfg = Config::new();
+        assert!(cfg.string_parameters_as_unicode());
+        cfg.send_string_parameters_as_unicode(false);
+        assert!(!cfg.string_parameters_as_unicode());
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -374,14 +374,37 @@ mod chrono_to_sql {
     }
 }
 
+fn encode_string_parameters(sql_type: SqlType, unicode: bool) -> SqlType {
+    if unicode {
+        return sql_type;
+    }
+
+    match sql_type {
+        SqlType::NVarchar(value, len) => SqlType::Varchar(value, len),
+        SqlType::NVarcharMax(value) => SqlType::VarcharMax(value),
+        other => other,
+    }
+}
+
 /// Build a Vec<RpcParameter> from a slice of ToSql values, using positional
 /// naming (@P1, @P2, ...) like tiberius.
 pub fn build_params(params: &[&dyn ToSql]) -> Vec<RpcParameter> {
+    build_params_with_string_encoding(params, true)
+}
+
+pub(crate) fn build_params_with_string_encoding(
+    params: &[&dyn ToSql],
+    unicode: bool,
+) -> Vec<RpcParameter> {
     params
         .iter()
         .enumerate()
         .map(|(i, p)| {
-            RpcParameter::new(Some(format!("@P{}", i + 1)), StatusFlags::NONE, p.to_sql())
+            RpcParameter::new(
+                Some(format!("@P{}", i + 1)),
+                StatusFlags::NONE,
+                encode_string_parameters(p.to_sql(), unicode),
+            )
         })
         .collect()
 }
@@ -403,6 +426,18 @@ mod tests {
         let params = build_params(&[&1i32, &"test"]);
         assert_eq!(params.len(), 2);
         // name field is pub(crate) in mssql-tds, so we just verify count
+    }
+
+    #[test]
+    fn string_parameter_encoding_can_use_varchar() {
+        let ty = encode_string_parameters("hello".to_sql(), false);
+        assert!(matches!(ty, SqlType::Varchar(_, 4000)));
+    }
+
+    #[test]
+    fn string_parameter_encoding_defaults_to_nvarchar() {
+        let ty = encode_string_parameters("hello".to_sql(), true);
+        assert!(matches!(ty, SqlType::NVarchar(_, 4000)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #46. Closes #47. Closes #49.

Mirrors tiberius#414, tiberius#340, and tiberius#367.

Changes:
- Add `Config::client_name(name)` and pipe it to mssql-tds `ClientContext::workstation_id` for Login7.
- Add `Config::host_name_in_certificate(name)` and pipe it to `EncryptionOptions::host_name_in_cert`.
- Add `Config::send_string_parameters_as_unicode(bool)`; defaults to true, and when false binds string parameters as VARCHAR.

Not included: #48 / tiberius#224. `mssql-tds-preview` currently has no public independent `accept_invalid_hostnames` option to route to native-tls; it needs a downstream API first.

Validation:
- `cargo check --quiet`
- `cargo test --lib --quiet`