### PR TITLE
feat: Debug for ToSql + time/jiff crate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,10 +762,12 @@ dependencies = [
  "deadpool",
  "futures-core",
  "futures-util",
+ "jiff",
  "mssql-tds-preview",
  "rust_decimal",
  "serde_json",
  "thiserror",
+ "time",
  "tokio",
  "uuid",
 ]
@@ -911,6 +935,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ keywords = ["sql-server", "tds", "mssql", "tiberius", "database"]
 categories = ["database"]
 license = "MIT"
 
+[features]
+default = []
+time = ["dep:time"]
+jiff = ["dep:jiff"]
+
 [dependencies]
 mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.1", default-features = false }
 deadpool = "0.12"
@@ -16,6 +21,8 @@ rust_decimal = "1"
 uuid = "1"
 tokio = { version = "1", features = ["net"] }
 serde_json = "1"
+time = { version = "0.3", optional = true }
+jiff = { version = "0.2", optional = true, default-features = false }
 async-trait = "0.1"
 thiserror = "2"
 futures-core = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //! | Flag | Default | Description |
 //! |------|---------|-------------|
 //! | `json` | off | Enables [`serde_json::Value`] support for [`FromSql`] and [`ToSql`] |
+//! | `time` | off | Enables `time` crate support for [`FromSql`] and [`ToSql`] |
+//! | `jiff` | off | Enables `jiff` crate support for [`FromSql`] and [`ToSql`] |
 //!
 //! # Modules
 //!
@@ -87,7 +89,7 @@ pub use column::{Column, ColumnType};
 pub use config::{AuthMethod, Config, EncryptionLevel};
 pub use error::{Error, Result};
 pub use pool::{Pool, PooledConnection, TdsManager};
-pub use query::{ExecuteResult, QueryResult, ToSql};
+pub use query::{DebugParams, ExecuteResult, QueryResult, ToSql};
 pub use row::{ColumnIndex, FromSql, Row};
 
 // Re-export mssql-tds types that consumers might need for advanced use.

--- a/src/query.rs
+++ b/src/query.rs
@@ -192,11 +192,35 @@ impl futures_core::Stream for RowStream {
 pub trait ToSql: Send + Sync {
     /// Convert this value into an mssql-tds `SqlType` for parameter binding.
     fn to_sql(&self) -> SqlType;
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<sql param>")
+    }
+}
+
+impl std::fmt::Debug for dyn ToSql + '_ {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.debug_fmt(f)
+    }
+}
+
+pub struct DebugParams<'a>(pub &'a [&'a dyn ToSql]);
+
+impl std::fmt::Debug for DebugParams<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list()
+            .entries(self.0.iter().map(|p| *p as &dyn ToSql))
+            .finish()
+    }
 }
 
 impl ToSql for bool {
     fn to_sql(&self) -> SqlType {
         SqlType::Bit(Some(*self))
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -204,11 +228,19 @@ impl ToSql for u8 {
     fn to_sql(&self) -> SqlType {
         SqlType::TinyInt(Some(*self))
     }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
 }
 
 impl ToSql for i16 {
     fn to_sql(&self) -> SqlType {
         SqlType::SmallInt(Some(*self))
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -216,11 +248,19 @@ impl ToSql for i32 {
     fn to_sql(&self) -> SqlType {
         SqlType::Int(Some(*self))
     }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
 }
 
 impl ToSql for i64 {
     fn to_sql(&self) -> SqlType {
         SqlType::BigInt(Some(*self))
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -228,11 +268,19 @@ impl ToSql for f32 {
     fn to_sql(&self) -> SqlType {
         SqlType::Real(Some(*self))
     }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
 }
 
 impl ToSql for f64 {
     fn to_sql(&self) -> SqlType {
         SqlType::Float(Some(*self))
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -243,11 +291,19 @@ impl ToSql for &str {
             4000, // default max length
         )
     }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
 }
 
 impl ToSql for String {
     fn to_sql(&self) -> SqlType {
         SqlType::NVarchar(Some(SqlString::from_utf8_string(self.clone())), 4000)
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
     }
 }
 
@@ -269,6 +325,17 @@ impl<T: ToSql + Default> ToSql for Option<T> {
                 // For simplicity, default to NVarchar NULL.
                 SqlType::NVarchar(None, 4000)
             }
+        }
+    }
+
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Some(v) => {
+                f.write_str("Some(")?;
+                v.debug_fmt(f)?;
+                f.write_str(")")
+            }
+            None => f.write_str("None"),
         }
     }
 }
@@ -374,6 +441,148 @@ mod chrono_to_sql {
     }
 }
 
+#[cfg(feature = "time")]
+mod time_to_sql {
+    use super::{SqlType, ToSql};
+    use chrono::Datelike;
+    use mssql_tds::datatypes::column_values::{
+        SqlDate, SqlDateTime2, SqlDateTimeOffset, SqlTime, DEFAULT_VARTIME_SCALE,
+    };
+    use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    fn date_to_sql(d: Date) -> SqlDate {
+        let chrono_date =
+            chrono::NaiveDate::from_ymd_opt(d.year(), u8::from(d.month()) as u32, d.day() as u32)
+                .expect("date out of SQL Server DATE range (0001-01-01..=9999-12-31)");
+        SqlDate::create((chrono_date.num_days_from_ce() - 1) as u32)
+            .expect("date out of SQL Server DATE range (0001-01-01..=9999-12-31)")
+    }
+
+    fn time_to_sql(t: Time) -> SqlTime {
+        let nanos_since_midnight = (t.hour() as u64) * 3_600_000_000_000
+            + (t.minute() as u64) * 60_000_000_000
+            + (t.second() as u64) * 1_000_000_000
+            + t.nanosecond() as u64;
+        SqlTime {
+            time_nanoseconds: nanos_since_midnight / 100,
+            scale: DEFAULT_VARTIME_SCALE,
+        }
+    }
+
+    fn primitive_dt_to_sql(dt: PrimitiveDateTime) -> SqlDateTime2 {
+        SqlDateTime2 {
+            days: date_to_sql(dt.date()).get_days(),
+            time: time_to_sql(dt.time()),
+        }
+    }
+
+    impl ToSql for Date {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Date(Some(date_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for Time {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Time(Some(time_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for PrimitiveDateTime {
+        fn to_sql(&self) -> SqlType {
+            SqlType::DateTime2(Some(primitive_dt_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for OffsetDateTime {
+        fn to_sql(&self) -> SqlType {
+            let offset = self.offset();
+            let utc = self.to_offset(UtcOffset::UTC);
+            SqlType::DateTimeOffset(Some(SqlDateTimeOffset {
+                datetime2: primitive_dt_to_sql(PrimitiveDateTime::new(utc.date(), utc.time())),
+                offset: (offset.whole_seconds() / 60) as i16,
+            }))
+        }
+    }
+}
+
+#[cfg(feature = "jiff")]
+mod jiff_to_sql {
+    use super::{SqlType, ToSql};
+    use chrono::Datelike;
+    use jiff::{civil, tz::TimeZone, Timestamp, Zoned};
+    use mssql_tds::datatypes::column_values::{
+        SqlDate, SqlDateTime2, SqlDateTimeOffset, SqlTime, DEFAULT_VARTIME_SCALE,
+    };
+
+    fn date_to_sql(d: civil::Date) -> SqlDate {
+        let chrono_date =
+            chrono::NaiveDate::from_ymd_opt(d.year() as i32, d.month() as u32, d.day() as u32)
+                .expect("date out of SQL Server DATE range (0001-01-01..=9999-12-31)");
+        SqlDate::create((chrono_date.num_days_from_ce() - 1) as u32)
+            .expect("date out of SQL Server DATE range (0001-01-01..=9999-12-31)")
+    }
+
+    fn time_to_sql(t: civil::Time) -> SqlTime {
+        let nanos_since_midnight = (t.hour() as u64) * 3_600_000_000_000
+            + (t.minute() as u64) * 60_000_000_000
+            + (t.second() as u64) * 1_000_000_000
+            + t.subsec_nanosecond() as u64;
+        SqlTime {
+            time_nanoseconds: nanos_since_midnight / 100,
+            scale: DEFAULT_VARTIME_SCALE,
+        }
+    }
+
+    fn datetime_to_sql(dt: civil::DateTime) -> SqlDateTime2 {
+        SqlDateTime2 {
+            days: date_to_sql(dt.date()).get_days(),
+            time: time_to_sql(dt.time()),
+        }
+    }
+
+    fn timestamp_to_sql(timestamp: Timestamp, offset_minutes: i16) -> SqlDateTimeOffset {
+        let utc = TimeZone::UTC.to_datetime(timestamp);
+        SqlDateTimeOffset {
+            datetime2: datetime_to_sql(utc),
+            offset: offset_minutes,
+        }
+    }
+
+    impl ToSql for civil::Date {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Date(Some(date_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for civil::Time {
+        fn to_sql(&self) -> SqlType {
+            SqlType::Time(Some(time_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for civil::DateTime {
+        fn to_sql(&self) -> SqlType {
+            SqlType::DateTime2(Some(datetime_to_sql(*self)))
+        }
+    }
+
+    impl ToSql for Timestamp {
+        fn to_sql(&self) -> SqlType {
+            SqlType::DateTimeOffset(Some(timestamp_to_sql(*self, 0)))
+        }
+    }
+
+    impl ToSql for Zoned {
+        fn to_sql(&self) -> SqlType {
+            SqlType::DateTimeOffset(Some(timestamp_to_sql(
+                self.timestamp(),
+                (self.offset().seconds() / 60) as i16,
+            )))
+        }
+    }
+}
+
 fn encode_string_parameters(sql_type: SqlType, unicode: bool) -> SqlType {
     if unicode {
         return sql_type;
@@ -426,6 +635,35 @@ mod tests {
         let params = build_params(&[&1i32, &"test"]);
         assert_eq!(params.len(), 2);
         // name field is pub(crate) in mssql-tds, so we just verify count
+    }
+
+    #[test]
+    fn debug_params_formats_values() {
+        let none = None::<i32>;
+        let params: &[&dyn ToSql] = &[&1i32, &"test", &none];
+        assert_eq!(format!("{:?}", DebugParams(params)), r#"[1, "test", None]"#);
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn time_date_roundtrips_through_column_data() {
+        let date = time::Date::from_calendar_date(2024, time::Month::February, 29).unwrap();
+        let SqlType::Date(Some(sql_date)) = date.to_sql() else {
+            panic!("expected SQL date")
+        };
+        let value = ColumnValues::Date(sql_date);
+        assert_eq!(crate::FromSql::from_sql(&value), Some(date));
+    }
+
+    #[cfg(feature = "jiff")]
+    #[test]
+    fn jiff_date_roundtrips_through_column_data() {
+        let date = jiff::civil::date(2024, 2, 29);
+        let SqlType::Date(Some(sql_date)) = date.to_sql() else {
+            panic!("expected SQL date")
+        };
+        let value = ColumnValues::Date(sql_date);
+        assert_eq!(crate::FromSql::from_sql(&value), Some(date));
     }
 
     #[test]

--- a/src/row.rs
+++ b/src/row.rs
@@ -437,6 +437,136 @@ impl<'a> FromSql<'a> for chrono::DateTime<chrono::FixedOffset> {
     }
 }
 
+#[cfg(feature = "time")]
+mod time_from_sql {
+    use super::{ColumnValues, FromSql};
+    use chrono::{Datelike, Timelike};
+    use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    fn date_from_chrono(date: chrono::NaiveDate) -> Option<Date> {
+        Date::from_calendar_date(
+            date.year(),
+            Month::try_from(date.month() as u8).ok()?,
+            date.day() as u8,
+        )
+        .ok()
+    }
+
+    fn time_from_chrono(time: chrono::NaiveTime) -> Option<Time> {
+        Time::from_hms_nano(
+            time.hour() as u8,
+            time.minute() as u8,
+            time.second() as u8,
+            time.nanosecond(),
+        )
+        .ok()
+    }
+
+    impl<'a> FromSql<'a> for Date {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            date_from_chrono(chrono::NaiveDate::from_sql(val)?)
+        }
+    }
+
+    impl<'a> FromSql<'a> for Time {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            time_from_chrono(chrono::NaiveTime::from_sql(val)?)
+        }
+    }
+
+    impl<'a> FromSql<'a> for PrimitiveDateTime {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            let dt = chrono::NaiveDateTime::from_sql(val)?;
+            Some(PrimitiveDateTime::new(
+                date_from_chrono(dt.date())?,
+                time_from_chrono(dt.time())?,
+            ))
+        }
+    }
+
+    impl<'a> FromSql<'a> for OffsetDateTime {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            let dt = chrono::DateTime::<chrono::FixedOffset>::from_sql(val)?;
+            let offset = UtcOffset::from_whole_seconds(dt.offset().local_minus_utc()).ok()?;
+            let utc = PrimitiveDateTime::new(
+                date_from_chrono(dt.naive_utc().date())?,
+                time_from_chrono(dt.naive_utc().time())?,
+            )
+            .assume_utc();
+            Some(utc.to_offset(offset))
+        }
+    }
+}
+
+#[cfg(feature = "jiff")]
+mod jiff_from_sql {
+    use super::{ColumnValues, FromSql};
+    use chrono::{Datelike, Timelike};
+    use jiff::{civil, tz::Offset, Timestamp, Zoned};
+
+    fn date_from_chrono(date: chrono::NaiveDate) -> Option<civil::Date> {
+        civil::Date::new(date.year() as i16, date.month() as i8, date.day() as i8).ok()
+    }
+
+    fn time_from_chrono(time: chrono::NaiveTime) -> Option<civil::Time> {
+        civil::Time::new(
+            time.hour() as i8,
+            time.minute() as i8,
+            time.second() as i8,
+            time.nanosecond() as i32,
+        )
+        .ok()
+    }
+
+    fn datetime_from_chrono(dt: chrono::NaiveDateTime) -> Option<civil::DateTime> {
+        civil::DateTime::new(
+            dt.year() as i16,
+            dt.month() as i8,
+            dt.day() as i8,
+            dt.hour() as i8,
+            dt.minute() as i8,
+            dt.second() as i8,
+            dt.nanosecond() as i32,
+        )
+        .ok()
+    }
+
+    impl<'a> FromSql<'a> for civil::Date {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            date_from_chrono(chrono::NaiveDate::from_sql(val)?)
+        }
+    }
+
+    impl<'a> FromSql<'a> for civil::Time {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            time_from_chrono(chrono::NaiveTime::from_sql(val)?)
+        }
+    }
+
+    impl<'a> FromSql<'a> for civil::DateTime {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            datetime_from_chrono(chrono::NaiveDateTime::from_sql(val)?)
+        }
+    }
+
+    impl<'a> FromSql<'a> for Timestamp {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            let dt = chrono::DateTime::<chrono::FixedOffset>::from_sql(val)?;
+            Timestamp::new(dt.timestamp(), dt.timestamp_subsec_nanos() as i32).ok()
+        }
+    }
+
+    impl<'a> FromSql<'a> for Zoned {
+        fn from_sql(val: &'a ColumnValues) -> Option<Self> {
+            let dt = chrono::DateTime::<chrono::FixedOffset>::from_sql(val)?;
+            let timestamp =
+                Timestamp::new(dt.timestamp(), dt.timestamp_subsec_nanos() as i32).ok()?;
+            let offset = Offset::from_seconds(dt.offset().local_minus_utc()).ok()?;
+            Some(timestamp.to_zoned(offset.to_time_zone()))
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Decimal
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #64, #67, #68.

Adds Debug derivation support for ToSql, plus optional time and jiff crate ToSql/FromSql impls behind cargo features. Mirrors existing chrono pattern.