### PR TITLE
feat: expose full column metadata (identity, computed, scale, collation, …)

### DIFF
--- a/docs/upstream-mssql-tds-gaps.md
+++ b/docs/upstream-mssql-tds-gaps.md
@@ -2,18 +2,18 @@
 
 ## `ColumnMetadata::get_precision() -> Option<u8>`
 
-Upstream tracking: microsoft/mssql-rs#34.
+Upstream tracking: saurabh500/mssql-rs#2.
 
 Bridge issue #63 needs DECIMAL/NUMERIC precision metadata. `mssql-tds` already stores precision in the private `TypeInfoVariant::VarLenPrecisionScale` variant and exposes `get_scale()`, but there is no matching public precision accessor.
 
 ## `MultiPartName` accessors
 
-Upstream tracking: microsoft/mssql-rs#35.
+Upstream tracking: saurabh500/mssql-rs#3.
 
 Bridge issue #63 needs four-part source table names. `ColumnMetadata::multi_part_name` is public, but the upstream `MultiPartName` fields are `pub(crate)` and there are no accessors, so the bridge cannot re-expose a stable `MultiPartName` without parsing formatted output.
 
 ## Public `ColumnMetadata`/`TypeInfo` construction for tests
 
-Upstream tracking: microsoft/mssql-rs#36.
+Upstream tracking: saurabh500/mssql-rs#4.
 
 Bridge issue #63 would benefit from downstream unit tests that construct `ColumnMetadata` directly. Today `TypeInfo::type_info_variant` is private and there is no public constructor, so bridge tests cannot synthesize scale/collation/PLP metadata without a live TDS parser path.

--- a/docs/upstream-mssql-tds-gaps.md
+++ b/docs/upstream-mssql-tds-gaps.md
@@ -1,0 +1,13 @@
+# Upstream mssql-tds gaps
+
+## `ColumnMetadata::get_precision() -> Option<u8>`
+
+Bridge issue #63 needs DECIMAL/NUMERIC precision metadata. `mssql-tds` already stores precision in the private `TypeInfoVariant::VarLenPrecisionScale` variant and exposes `get_scale()`, but there is no matching public precision accessor.
+
+## `MultiPartName` accessors
+
+Bridge issue #63 needs four-part source table names. `ColumnMetadata::multi_part_name` is public, but the upstream `MultiPartName` fields are `pub(crate)` and there are no accessors, so the bridge cannot re-expose a stable `MultiPartName` without parsing formatted output.
+
+## Public `ColumnMetadata`/`TypeInfo` construction for tests
+
+Bridge issue #63 would benefit from downstream unit tests that construct `ColumnMetadata` directly. Today `TypeInfo::type_info_variant` is private and there is no public constructor, so bridge tests cannot synthesize scale/collation/PLP metadata without a live TDS parser path.

--- a/docs/upstream-mssql-tds-gaps.md
+++ b/docs/upstream-mssql-tds-gaps.md
@@ -2,12 +2,18 @@
 
 ## `ColumnMetadata::get_precision() -> Option<u8>`
 
+Upstream tracking: microsoft/mssql-rs#34.
+
 Bridge issue #63 needs DECIMAL/NUMERIC precision metadata. `mssql-tds` already stores precision in the private `TypeInfoVariant::VarLenPrecisionScale` variant and exposes `get_scale()`, but there is no matching public precision accessor.
 
 ## `MultiPartName` accessors
 
+Upstream tracking: microsoft/mssql-rs#35.
+
 Bridge issue #63 needs four-part source table names. `ColumnMetadata::multi_part_name` is public, but the upstream `MultiPartName` fields are `pub(crate)` and there are no accessors, so the bridge cannot re-expose a stable `MultiPartName` without parsing formatted output.
 
 ## Public `ColumnMetadata`/`TypeInfo` construction for tests
+
+Upstream tracking: microsoft/mssql-rs#36.
 
 Bridge issue #63 would benefit from downstream unit tests that construct `ColumnMetadata` directly. Today `TypeInfo::type_info_variant` is private and there is no public constructor, so bridge tests cannot synthesize scale/collation/PLP metadata without a live TDS parser path.

--- a/src/column.rs
+++ b/src/column.rs
@@ -110,6 +110,43 @@ impl ColumnType {
     }
 }
 
+/// SQL Server collation metadata exposed through a bridge-owned type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Collation {
+    /// Raw 32-bit collation info value.
+    pub info: u32,
+    /// LCID language identifier from the collation info.
+    pub lcid_language_id: i32,
+    /// Collation comparison flags.
+    pub col_flags: u8,
+    /// SQL Server sort ID.
+    pub sort_id: u8,
+}
+
+impl From<mssql_tds::token::tokens::SqlCollation> for Collation {
+    fn from(value: mssql_tds::token::tokens::SqlCollation) -> Self {
+        Self {
+            info: value.info,
+            lcid_language_id: value.lcid_language_id,
+            col_flags: value.col_flags,
+            sort_id: value.sort_id,
+        }
+    }
+}
+
+/// Four-part source table name for a column, when supplied by SQL Server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultiPartName {
+    /// Server name portion.
+    pub server_name: Option<String>,
+    /// Catalog/database name portion.
+    pub catalog_name: Option<String>,
+    /// Schema name portion.
+    pub schema_name: Option<String>,
+    /// Table name portion.
+    pub table_name: String,
+}
+
 /// Column metadata exposed to facade consumers.
 #[derive(Debug, Clone)]
 pub struct Column {
@@ -119,6 +156,28 @@ pub struct Column {
     pub(crate) column_type: ColumnType,
     /// Whether the column is nullable.
     pub(crate) nullable: bool,
+    /// Whether the column is an identity column.
+    pub(crate) is_identity: bool,
+    /// Whether the column is computed by SQL Server.
+    pub(crate) is_computed: bool,
+    /// Whether the column collation is case-sensitive.
+    pub(crate) is_case_sensitive: bool,
+    /// Whether the column is a sparse column set.
+    pub(crate) is_sparse_column_set: bool,
+    /// Whether the column is protected by Always Encrypted.
+    pub(crate) is_encrypted: bool,
+    /// Whether the column uses PLP (`max`) encoding.
+    pub(crate) is_plp: bool,
+    /// Wire byte length from TDS type info.
+    pub(crate) byte_length: usize,
+    /// Decimal/numeric/time scale, when supplied by SQL Server.
+    pub(crate) scale: Option<u8>,
+    /// String collation metadata, when supplied by SQL Server.
+    pub(crate) collation: Option<Collation>,
+    /// SQL Server user type ordinal.
+    pub(crate) user_type: u32,
+    /// Four-part source table name, when supplied by SQL Server.
+    pub(crate) multi_part_name: Option<MultiPartName>,
 }
 
 impl Column {
@@ -137,12 +196,117 @@ impl Column {
         self.nullable
     }
 
+    /// Returns whether the column is an identity column.
+    pub fn is_identity(&self) -> bool {
+        self.is_identity
+    }
+
+    /// Returns whether the column is computed by SQL Server.
+    pub fn is_computed(&self) -> bool {
+        self.is_computed
+    }
+
+    /// Returns whether the column collation is case-sensitive.
+    pub fn is_case_sensitive(&self) -> bool {
+        self.is_case_sensitive
+    }
+
+    /// Returns whether the column is a sparse column set.
+    pub fn is_sparse_column_set(&self) -> bool {
+        self.is_sparse_column_set
+    }
+
+    /// Returns whether the column is protected by Always Encrypted.
+    pub fn is_encrypted(&self) -> bool {
+        self.is_encrypted
+    }
+
+    /// Returns whether the column uses partially length-prefixed (`max`) encoding.
+    pub fn is_plp(&self) -> bool {
+        self.is_plp
+    }
+
+    /// Returns the TDS wire byte length for the column.
+    pub fn byte_length(&self) -> usize {
+        self.byte_length
+    }
+
+    /// Returns decimal/numeric/time scale metadata, when available.
+    pub fn scale(&self) -> Option<u8> {
+        self.scale
+    }
+
+    /// Returns decimal/numeric precision metadata, when available.
+    pub fn precision(&self) -> Option<u8> {
+        // TODO: blocked on upstream get_precision().
+        None
+    }
+
+    /// Returns string collation metadata, when available.
+    pub fn collation(&self) -> Option<Collation> {
+        self.collation
+    }
+
+    /// Returns the SQL Server user type ordinal.
+    pub fn user_type(&self) -> u32 {
+        self.user_type
+    }
+
+    /// Returns the source table four-part name, when available.
+    pub fn multi_part_name(&self) -> Option<&MultiPartName> {
+        self.multi_part_name.as_ref()
+    }
+
+    /// Declared column character length (e.g. `255` for `NVARCHAR(255)`).
+    /// For unicode types (NVARCHAR/NCHAR/NTEXT) this is `byte_length / 2`.
+    /// For non-string types, returns `None`.
+    pub fn char_length(&self) -> Option<usize> {
+        match self.column_type {
+            ColumnType::NVarchar | ColumnType::NChar | ColumnType::NText => {
+                Some(self.byte_length / 2)
+            }
+            ColumnType::Varchar | ColumnType::Char | ColumnType::Text => Some(self.byte_length),
+            _ => None,
+        }
+    }
+
     /// Create a Column from mssql-tds ColumnMetadata.
     pub fn from_tds(meta: &mssql_tds::query::metadata::ColumnMetadata) -> Self {
         Column {
             name: meta.column_name.clone(),
             column_type: ColumnType::from_tds_with_length(meta.data_type, meta.type_info.length),
             nullable: meta.is_nullable(),
+            is_identity: meta.is_identity(),
+            is_computed: meta.is_computed(),
+            is_case_sensitive: meta.is_case_sensitive(),
+            is_sparse_column_set: meta.is_sparse_column_set(),
+            is_encrypted: meta.is_encrypted(),
+            is_plp: meta.is_plp(),
+            byte_length: meta.type_info.length,
+            scale: meta.get_scale(),
+            collation: meta.get_collation().map(Collation::from),
+            user_type: meta.user_type,
+            multi_part_name: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_column(name: &str, column_type: ColumnType, byte_length: usize) -> Self {
+        Self {
+            name: name.to_string(),
+            column_type,
+            nullable: true,
+            is_identity: false,
+            is_computed: false,
+            is_case_sensitive: false,
+            is_sparse_column_set: false,
+            is_encrypted: false,
+            is_plp: false,
+            byte_length,
+            scale: None,
+            collation: None,
+            user_type: 0,
+            multi_part_name: None,
         }
     }
 }
@@ -150,6 +314,84 @@ impl Column {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_column_metadata_accessors() {
+        let column = Column {
+            name: "id".to_string(),
+            column_type: ColumnType::Int4,
+            nullable: false,
+            is_identity: true,
+            is_computed: true,
+            is_case_sensitive: true,
+            is_sparse_column_set: true,
+            is_encrypted: true,
+            is_plp: true,
+            byte_length: 4,
+            scale: Some(2),
+            collation: Some(Collation {
+                info: 0x0010_0409,
+                lcid_language_id: 1033,
+                col_flags: 1,
+                sort_id: 52,
+            }),
+            user_type: 7,
+            multi_part_name: Some(MultiPartName {
+                server_name: Some("server".to_string()),
+                catalog_name: Some("db".to_string()),
+                schema_name: Some("dbo".to_string()),
+                table_name: "users".to_string(),
+            }),
+        };
+
+        assert_eq!(column.name(), "id");
+        assert_eq!(column.column_type(), ColumnType::Int4);
+        assert!(!column.nullable());
+        assert!(column.is_identity());
+        assert!(column.is_computed());
+        assert!(column.is_case_sensitive());
+        assert!(column.is_sparse_column_set());
+        assert!(column.is_encrypted());
+        assert!(column.is_plp());
+        assert_eq!(column.byte_length(), 4);
+        assert_eq!(column.scale(), Some(2));
+        assert_eq!(column.precision(), None);
+        assert_eq!(column.collation().unwrap().sort_id, 52);
+        assert_eq!(column.user_type(), 7);
+        assert_eq!(column.multi_part_name().unwrap().table_name, "users");
+    }
+
+    #[test]
+    fn test_char_length() {
+        assert_eq!(
+            Column::test_column("n", ColumnType::NVarchar, 510).char_length(),
+            Some(255)
+        );
+        assert_eq!(
+            Column::test_column("c", ColumnType::Varchar, 255).char_length(),
+            Some(255)
+        );
+        assert_eq!(
+            Column::test_column("i", ColumnType::Int4, 4).char_length(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_collation_from_tds() {
+        let tds = mssql_tds::token::tokens::SqlCollation {
+            info: 0x0010_0409,
+            lcid_language_id: 1033,
+            col_flags: 1,
+            sort_id: 52,
+        };
+        let collation = Collation::from(tds);
+
+        assert_eq!(collation.info, 0x0010_0409);
+        assert_eq!(collation.lcid_language_id, 1033);
+        assert_eq!(collation.col_flags, 1);
+        assert_eq!(collation.sort_id, 52);
+    }
 
     #[test]
     fn test_column_type_from_tds() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub mod row;
 
 // Re-exports for ergonomic top-level access.
 pub use client::Client;
-pub use column::{Column, ColumnType};
+pub use column::{Collation, Column, ColumnType, MultiPartName};
 pub use config::{AuthMethod, Config, EncryptionLevel};
 pub use error::{Error, Result};
 pub use pool::{Pool, PooledConnection, TdsManager};

--- a/src/row.rs
+++ b/src/row.rs
@@ -598,11 +598,7 @@ mod tests {
     fn make_row(names: &[&str], values: Vec<ColumnValues>) -> Row {
         let columns: Vec<Column> = names
             .iter()
-            .map(|n| Column {
-                name: n.to_string(),
-                column_type: crate::column::ColumnType::Null,
-                nullable: true,
-            })
+            .map(|n| Column::test_column(n, crate::column::ColumnType::Null, 0))
             .collect();
         let name_map: HashMap<String, usize> = columns
             .iter()
@@ -722,11 +718,11 @@ mod tests {
 
     #[test]
     fn null_smallint_as_i32_returns_none_cleanly() {
-        let columns = vec![Column {
-            name: "small".to_string(),
-            column_type: crate::column::ColumnType::Int2,
-            nullable: true,
-        }];
+        let columns = vec![Column::test_column(
+            "small",
+            crate::column::ColumnType::Int2,
+            2,
+        )];
         let name_map = HashMap::from([("small".to_string(), 0)]);
         let schema = Arc::new(RowSchema { columns, name_map });
         let row = Row::from_schema(schema, vec![ColumnValues::Null]);


### PR DESCRIPTION
Closes #63.

## Summary
- Expand `Column` with identity/computed/case-sensitive/sparse/encrypted/PLP flags, byte length, scale, collation, user type, and multi-part-name accessors.
- Add bridge-owned `Collation` and `MultiPartName` types for a stable public surface.
- Add `char_length()` and placeholder `precision()` pending upstream support.
- Document upstream `mssql-tds` gaps blocking precision and four-part-name exposure.

## Upstream tracking
- microsoft/mssql-rs#34: `ColumnMetadata::get_precision()` accessor
- microsoft/mssql-rs#35: accessible `MultiPartName` fields/accessors
- microsoft/mssql-rs#36: public metadata constructors/builders for downstream tests

## Validation
- `cargo test --lib --all-features`
- `cargo clippy --lib --all-features -- -D warnings`