### PR TITLE
feat(config): add MultiSubnetFailover

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,6 +127,7 @@ pub struct Config {
     instance_name: Option<String>,
     client_name: Option<String>,
     send_string_parameters_as_unicode: bool,
+    multi_subnet_failover: bool,
 }
 
 impl Config {
@@ -149,6 +150,7 @@ impl Config {
             instance_name: None,
             client_name: None,
             send_string_parameters_as_unicode: true,
+            multi_subnet_failover: false,
         }
     }
 
@@ -247,6 +249,31 @@ impl Config {
     pub fn encryption(&mut self, level: EncryptionLevel) -> &mut Self {
         self.encryption = level;
         self
+    }
+
+    /// Enable `MultiSubnetFailover` (MSF) connection mode.
+    ///
+    /// With SQL Server Always On Availability Groups whose listener spans
+    /// multiple subnets, the listener DNS record contains every replica IP.
+    /// With MSF enabled, the client resolves all A/AAAA records and races
+    /// `TcpStream::connect` against them in parallel, taking the first that
+    /// completes the TCP handshake. This drives sub-second failover when a
+    /// replica becomes unreachable.
+    ///
+    /// Notes:
+    /// - MSF is only meaningful for **TCP** connections. mssql-tds rejects
+    ///   the combination with Named Pipes / Shared Memory / LocalDB.
+    /// - Off by default (single-target connect, the typical case).
+    /// - Mirrors Microsoft .NET's `MultiSubnetFailover=true` connection
+    ///   string keyword.
+    pub fn multi_subnet_failover(&mut self, enabled: bool) -> &mut Self {
+        self.multi_subnet_failover = enabled;
+        self
+    }
+
+    /// Returns whether `MultiSubnetFailover` is enabled on this config.
+    pub fn is_multi_subnet_failover(&self) -> bool {
+        self.multi_subnet_failover
     }
 
     /// Set the application name reported to the server in `sys.dm_exec_sessions`.
@@ -348,6 +375,8 @@ impl Config {
         } else {
             mssql_tds::message::login_options::ApplicationIntent::ReadWrite
         };
+
+        ctx.multi_subnet_failover = self.multi_subnet_failover;
 
         // UserAgent feature extension (TDS 0x10)
         let bridge_version = env!("CARGO_PKG_VERSION");
@@ -599,5 +628,24 @@ mod tests {
         assert_eq!(opts.mode, mssql_tds::core::EncryptionSetting::Strict);
         assert_eq!(opts.host_name_in_cert.as_deref(), Some("sql.example.com"));
         assert_eq!(opts.server_certificate.as_deref(), Some("/etc/ssl/ca.pem"));
+    }
+
+    #[test]
+    fn multi_subnet_failover_defaults_to_off() {
+        let cfg = Config::new();
+        assert!(!cfg.is_multi_subnet_failover());
+        assert!(!cfg.to_client_context().multi_subnet_failover);
+    }
+
+    #[test]
+    fn multi_subnet_failover_setter_propagates() {
+        let mut cfg = Config::new();
+        cfg.multi_subnet_failover(true);
+        assert!(cfg.is_multi_subnet_failover());
+        assert!(cfg.to_client_context().multi_subnet_failover);
+
+        cfg.multi_subnet_failover(false);
+        assert!(!cfg.is_multi_subnet_failover());
+        assert!(!cfg.to_client_context().multi_subnet_failover);
     }
 }

--- a/tests/multi_subnet_failover.rs
+++ b/tests/multi_subnet_failover.rs
@@ -36,7 +36,9 @@ fn msf_config() -> Option<Config> {
 #[tokio::test]
 async fn multi_subnet_failover_connects_to_single_endpoint() {
     let Some(cfg) = msf_config() else {
-        eprintln!("skipping multi_subnet_failover_connects_to_single_endpoint: TEST_DB_PASSWORD not set");
+        eprintln!(
+            "skipping multi_subnet_failover_connects_to_single_endpoint: TEST_DB_PASSWORD not set"
+        );
         return;
     };
     assert!(cfg.is_multi_subnet_failover());

--- a/tests/multi_subnet_failover.rs
+++ b/tests/multi_subnet_failover.rs
@@ -1,0 +1,53 @@
+//! MultiSubnetFailover integration test (issue #61).
+//!
+//! Real MSF only matters against an Always On listener whose DNS record
+//! resolves to multiple IPs across subnets — we don't have one of those in
+//! CI. What we *can* assert in CI is that enabling MSF against a normal
+//! single-IP endpoint still connects and queries successfully (i.e., the
+//! parallel-connect code path doesn't break the common case). This is the
+//! same posture the .NET driver tests take for MSF in their bring-up suite.
+//!
+//! Reuses the standard `TEST_DB_*` env vars; skips when `TEST_DB_PASSWORD`
+//! is unset.
+
+use mssql_tiberius_bridge::{AuthMethod, Client, Config};
+
+fn msf_config() -> Option<Config> {
+    let password = std::env::var("TEST_DB_PASSWORD").ok()?;
+
+    let mut cfg = Config::new();
+    cfg.host(std::env::var("TEST_DB_HOST").unwrap_or_else(|_| "localhost".into()))
+        .port(
+            std::env::var("TEST_DB_PORT")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(1433),
+        )
+        .database(std::env::var("TEST_DB_NAME").unwrap_or_else(|_| "master".into()))
+        .authentication(AuthMethod::sql_server(
+            std::env::var("TEST_DB_USER").unwrap_or_else(|_| "sa".into()),
+            password,
+        ))
+        .trust_cert()
+        .multi_subnet_failover(true);
+    Some(cfg)
+}
+
+#[tokio::test]
+async fn multi_subnet_failover_connects_to_single_endpoint() {
+    let Some(cfg) = msf_config() else {
+        eprintln!("skipping multi_subnet_failover_connects_to_single_endpoint: TEST_DB_PASSWORD not set");
+        return;
+    };
+    assert!(cfg.is_multi_subnet_failover());
+
+    let mut client = Client::connect(&cfg)
+        .await
+        .expect("MSF connect against single-IP endpoint should succeed");
+    let rows = client
+        .simple_query("SELECT 1 AS value")
+        .await
+        .expect("query failed")
+        .into_first_result();
+    assert_eq!(rows[0].get::<i32, _>("value"), Some(1));
+}


### PR DESCRIPTION
Closes #61.

## Summary

`mssql-tds` already implements the parallel-connect mechanic for MultiSubnetFailover (see `mssql-tds/src/connection/transport/parallel_connect.rs` and the `multi_subnet_failover` field on `ClientContext`). This PR exposes it on the bridge.

## Changes

- **`Config::multi_subnet_failover(bool)`** setter + **`is_multi_subnet_failover()`** getter.
- **`to_client_context()`** propagates the flag onto `ClientContext.multi_subnet_failover`.
- **Doc** on the setter explains: TCP-only, default off, equivalent to .NET's `MultiSubnetFailover=true`.
- **Unit tests** (`src/config.rs`):
  - default is `false`
  - setter round-trips onto `ClientContext`
- **Integration test** (`tests/multi_subnet_failover.rs`):
  - enables MSF against the standard single-IP `TEST_DB_HOST` endpoint and asserts `SELECT 1` still works
  - guards against the parallel-connect code path regressing the common single-target case (we can't stand up an Always On listener in CI)

## Out of scope

- Multi-replica DNS round-robin / actual race semantics — needs an Always On AG topology, which CI doesn't provide. mssql-tds has its own unit coverage for the parallel connector.

## Verification

```text
cargo test --lib config::          → 22 passed
cargo test --test multi_subnet_failover  → 1 passed (skips without TEST_DB_PASSWORD)
cargo clippy --lib --test multi_subnet_failover -- -D warnings → clean
```

Mirrors prisma/tiberius#337.
