### PR TITLE
ci(publish): make tag step idempotent vs release-plz

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,5 +52,23 @@ jobs:
       - name: Tag release
         if: "!inputs.dry_run"
         run: |
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+          # release-plz.yml may have already pushed this tag; in that case
+          # the publish step above still needs to run, but tagging is a
+          # no-op. Only fail if the tag exists locally/remotely AND points
+          # at a different commit than HEAD.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}" | awk '{print $1}')
+            HEAD_SHA=$(git rev-parse HEAD)
+            if [ "${REMOTE_SHA}" = "${HEAD_SHA}" ]; then
+              echo "ℹ️  Tag ${TAG} already exists at ${REMOTE_SHA} (matches HEAD); skipping."
+              exit 0
+            else
+              echo "::error::Tag ${TAG} already exists at ${REMOTE_SHA} but HEAD is ${HEAD_SHA}. Refusing to overwrite."
+              exit 1
+            fi
+          fi
+          git tag "${TAG}"
+          git push origin "${TAG}"
+          echo "🏷️  Tagged ${TAG}"


### PR DESCRIPTION
## Problem

`publish.yml`'s **Tag release** step has been failing on every recent run with:

```
! [rejected]  v0.1.0-preview.3 -> v0.1.0-preview.3 (already exists)
```

Two workflows tag the same version:

1. `release-plz.yml` → `release-plz-release` job → `release-plz/action@v0.5 release` tags `vX.Y.Z` and creates the GitHub Release as soon as a Release-PR merges to `main`.
2. `publish.yml` (manual `workflow_dispatch`) → `cargo publish` → then `git tag vX.Y.Z && git push`.

In the normal flow, release-plz runs first, so by the time `publish.yml` is dispatched the tag already exists on the remote and the push is rejected. The actual `cargo publish` succeeded; the workflow still fails because of this last step.

## Fix

Make the `Tag release` step idempotent:

- If `refs/tags/v$VERSION` exists on `origin` and points at `HEAD` → log and `exit 0`.
- If it exists but points at a **different** commit → fail loudly (don't silently overwrite).
- Otherwise → tag and push as before.

This handles both orderings — release-plz-first (today's flow) and publish.yml-first (if release-plz is ever disabled).

## Verification

- Re-running `publish.yml` after release-plz has already tagged will now succeed in the Tag step.
- The mismatch branch is exercised implicitly (any future drift between Cargo.toml and the tagged commit fails fast).

No behavior change to `cargo publish`; no change to release-plz.
