### PR TITLE
feat(row): add serde::Deserialize support behind 'serde' feature (closes #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,14 @@ jobs:
       - name: Unit tests
         run: cargo test --lib
 
+      - name: Unit tests (serde feature)
+        run: cargo test --lib --features serde
+
       - name: Doc tests
         run: cargo test --doc
+
+      - name: Doc tests (serde feature)
+        run: cargo test --doc --features serde
 
       - name: Integration tests with coverage
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "jiff",
  "mssql-tds-preview",
  "rust_decimal",
+ "serde",
  "serde_json",
  "thiserror",
  "time",
@@ -1237,6 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 default = []
 time = ["dep:time"]
 jiff = ["dep:jiff"]
+serde = ["dep:serde"]
 
 [dependencies]
 mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.1", default-features = false }
@@ -21,6 +22,7 @@ rust_decimal = "1"
 uuid = "1"
 tokio = { version = "1", features = ["net"] }
 serde_json = "1"
+serde = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
 jiff = { version = "0.2", optional = true, default-features = false }
 async-trait = "0.1"
@@ -30,3 +32,4 @@ async-stream = "0.3"
 
 [dev-dependencies]
 futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! | `json` | off | Enables [`serde_json::Value`] support for [`FromSql`] and [`ToSql`] |
 //! | `time` | off | Enables `time` crate support for [`FromSql`] and [`ToSql`] |
 //! | `jiff` | off | Enables `jiff` crate support for [`FromSql`] and [`ToSql`] |
+//! | `serde` | off | Enables `serde::Deserialize` for [`Row`] (see [`serde_de`]) |
 //!
 //! # Modules
 //!
@@ -82,6 +83,8 @@ pub mod error;
 pub mod pool;
 pub mod query;
 pub mod row;
+#[cfg(feature = "serde")]
+pub mod serde_de;
 
 // Re-exports for ergonomic top-level access.
 pub use client::Client;

--- a/src/row.rs
+++ b/src/row.rs
@@ -146,6 +146,52 @@ impl Row {
         self.values.get(idx)
     }
 
+    /// Pre-decoded UTF-8 string at the given index, if any. Used by the
+    /// `serde` deserializer and by `&str`-typed FromSql.
+    #[inline]
+    pub(crate) fn decoded_str_at(&self, idx: usize) -> Option<&str> {
+        self.decoded_strings.get(idx).and_then(|s| s.as_deref())
+    }
+
+    /// Deserialize this row into a `T` using `serde`. Consumes the row.
+    ///
+    /// Requires the `serde` cargo feature. See the
+    /// [`serde_de`](crate::serde_de) module for the field/type mapping rules.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "serde")]
+    /// # async fn ex(client: &mut mssql_tiberius_bridge::Client)
+    /// #     -> mssql_tiberius_bridge::Result<()> {
+    /// use serde::Deserialize;
+    /// use mssql_tiberius_bridge::Row;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct User { id: i64, name: String }
+    ///
+    /// let users: Vec<User> = client.query("SELECT id, name FROM users", &[])
+    ///     .await?
+    ///     .into_first_result()
+    ///     .into_iter()
+    ///     .map(Row::deserialize)
+    ///     .collect::<mssql_tiberius_bridge::Result<Vec<_>>>()?;
+    /// # Ok(()) }
+    /// ```
+    #[cfg(feature = "serde")]
+    pub fn deserialize<T: serde::de::DeserializeOwned>(self) -> Result<T> {
+        T::deserialize(crate::serde_de::RowDeserializer::new(&self))
+    }
+
+    /// Borrowed-deserialize variant: the resulting value can borrow `&str`
+    /// and `&[u8]` cells directly out of this row.
+    ///
+    /// Requires the `serde` cargo feature.
+    #[cfg(feature = "serde")]
+    pub fn deserialize_borrowed<'de, T: serde::Deserialize<'de>>(&'de self) -> Result<T> {
+        T::deserialize(crate::serde_de::RowDeserializer::new(self))
+    }
+
     /// Look up a column index by name (case-sensitive).
     pub fn column_index(&self, name: &str) -> Option<usize> {
         self.schema.name_map.get(name).copied()

--- a/src/row.rs
+++ b/src/row.rs
@@ -147,7 +147,8 @@ impl Row {
     }
 
     /// Pre-decoded UTF-8 string at the given index, if any. Used by the
-    /// `serde` deserializer and by `&str`-typed FromSql.
+    /// `serde` deserializer.
+    #[cfg(feature = "serde")]
     #[inline]
     pub(crate) fn decoded_str_at(&self, idx: usize) -> Option<&str> {
         self.decoded_strings.get(idx).and_then(|s| s.as_deref())

--- a/src/serde_de.rs
+++ b/src/serde_de.rs
@@ -1,0 +1,769 @@
+//! `serde::Deserialize` support for [`Row`].
+//!
+//! Gated behind the `serde` cargo feature. Enables ergonomic
+//! row → struct mapping:
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "serde")]
+//! # async fn example(client: &mut mssql_tiberius_bridge::Client) -> mssql_tiberius_bridge::Result<()> {
+//! use serde::Deserialize;
+//! use mssql_tiberius_bridge::Row;
+//!
+//! #[derive(Deserialize)]
+//! struct User {
+//!     id: i64,
+//!     name: String,
+//!     email: Option<String>,
+//! }
+//!
+//! let users: Vec<User> = client
+//!     .query("SELECT id, name, email FROM users", &[])
+//!     .await?
+//!     .into_first_result()
+//!     .into_iter()
+//!     .map(Row::deserialize)
+//!     .collect::<mssql_tiberius_bridge::Result<Vec<_>>>()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Field-name mapping
+//!
+//! Struct fields are matched to columns by **exact name** (case-sensitive,
+//! same lookup as [`Row::get`]). Use `#[serde(rename = "Name")]` to map to a
+//! column whose name doesn't match the field identifier.
+//!
+//! ## Type mapping
+//!
+//! | TDS column type                          | Visited as                          |
+//! |------------------------------------------|-------------------------------------|
+//! | `bit`                                    | `bool`                              |
+//! | `tinyint` / `smallint` / `int` / `bigint`| widening integer (`u8` → `i64`)     |
+//! | `real` / `float`                         | `f32` / `f64`                       |
+//! | `nvarchar` / `varchar` / `text` / `xml` / `json` | borrowed `&str` (UTF-8) |
+//! | `varbinary` / `binary` / `image`         | borrowed `&[u8]`                    |
+//! | `uniqueidentifier`                       | `&str` (lowercase hyphenated UUID)  |
+//! | `date` / `time` / `datetime` / `datetime2` / `datetimeoffset` / `smalldatetime` | ISO-8601 `String` |
+//! | `decimal` / `numeric`                    | `String` (`Display` of `DecimalParts`) |
+//! | `money` / `smallmoney`                   | `f64`                               |
+//! | `NULL`                                   | `Option::None` (when typed as `Option<T>`) or unit |
+//!
+//! Numeric coercion is forgiving: a column declared as `tinyint` will
+//! deserialize into a struct field of any integer width up to `i64`.
+//!
+//! ## Borrowed deserialization
+//!
+//! For borrowed `&str` / `&[u8]` fields, use [`Row::deserialize_borrowed`]
+//! which keeps the row alive for the lifetime of the resulting value.
+
+use mssql_tds::datatypes::column_values::ColumnValues;
+use serde::de::{
+    self, DeserializeSeed, Deserializer, IntoDeserializer, MapAccess, SeqAccess, Visitor,
+};
+
+use crate::error::{Error, Result};
+use crate::row::Row;
+
+// ---------------------------------------------------------------------------
+// serde::de::Error glue for our Error type
+// ---------------------------------------------------------------------------
+
+impl de::Error for Error {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        Error::Conversion(msg.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row -> Deserializer
+// ---------------------------------------------------------------------------
+
+/// `serde` deserializer that views a [`Row`] as a struct or map (column name → value)
+/// or as a sequence (positional values).
+pub struct RowDeserializer<'a> {
+    row: &'a Row,
+}
+
+impl<'a> RowDeserializer<'a> {
+    /// Wrap a row reference for serde deserialization.
+    pub fn new(row: &'a Row) -> Self {
+        Self { row }
+    }
+}
+
+impl<'de, 'a: 'de> Deserializer<'de> for RowDeserializer<'a> {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        // Default is map-style (struct-shaped consumers).
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_map(RowMapAccess {
+            row: self.row,
+            idx: 0,
+        })
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        visitor.visit_map(RowMapAccess {
+            row: self.row,
+            idx: 0,
+        })
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_seq(RowSeqAccess {
+            row: self.row,
+            idx: 0,
+        })
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(self, _len: usize, visitor: V) -> Result<V::Value> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct enum identifier ignored_any
+    }
+}
+
+struct RowMapAccess<'a> {
+    row: &'a Row,
+    idx: usize,
+}
+
+impl<'de, 'a: 'de> MapAccess<'de> for RowMapAccess<'a> {
+    type Error = Error;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>> {
+        if self.idx >= self.row.len() {
+            return Ok(None);
+        }
+        let name = self.row.columns()[self.idx].name.as_str();
+        // Use IntoDeserializer for &str → produces a borrowed-str deserializer.
+        seed.deserialize(name.into_deserializer()).map(Some)
+    }
+
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value> {
+        let val = self
+            .row
+            .raw_value(self.idx)
+            .ok_or(Error::ColumnIndexOutOfBounds {
+                index: self.idx,
+                count: self.row.len(),
+            })?;
+        let decoded = self.row.decoded_str_at(self.idx);
+        let result = seed.deserialize(ColumnValueDeserializer { val, decoded });
+        self.idx += 1;
+        result
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.row.len() - self.idx)
+    }
+}
+
+struct RowSeqAccess<'a> {
+    row: &'a Row,
+    idx: usize,
+}
+
+impl<'de, 'a: 'de> SeqAccess<'de> for RowSeqAccess<'a> {
+    type Error = Error;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>> {
+        if self.idx >= self.row.len() {
+            return Ok(None);
+        }
+        let val = self
+            .row
+            .raw_value(self.idx)
+            .ok_or(Error::ColumnIndexOutOfBounds {
+                index: self.idx,
+                count: self.row.len(),
+            })?;
+        let decoded = self.row.decoded_str_at(self.idx);
+        let v = seed.deserialize(ColumnValueDeserializer { val, decoded })?;
+        self.idx += 1;
+        Ok(Some(v))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.row.len() - self.idx)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ColumnValues -> Deserializer
+// ---------------------------------------------------------------------------
+
+struct ColumnValueDeserializer<'a> {
+    val: &'a ColumnValues,
+    decoded: Option<&'a str>,
+}
+
+impl<'a> ColumnValueDeserializer<'a> {
+    fn unsupported<T>(&self, target: &str) -> Result<T> {
+        Err(Error::Conversion(format!(
+            "cannot deserialize {:?} as {target}",
+            std::mem::discriminant(self.val)
+        )))
+    }
+
+    fn temporal_string(&self) -> Option<String> {
+        // Reuse the chrono FromSql impls already in row.rs to render a stable
+        // ISO-8601 representation. This keeps the deserializer in sync with
+        // the rest of the bridge's temporal semantics.
+        use crate::row::FromSql;
+        match self.val {
+            ColumnValues::Date(_) => {
+                chrono::NaiveDate::from_sql(self.val).map(|d| d.format("%Y-%m-%d").to_string())
+            }
+            ColumnValues::Time(_) => {
+                chrono::NaiveTime::from_sql(self.val).map(|t| t.format("%H:%M:%S%.f").to_string())
+            }
+            ColumnValues::DateTime(_)
+            | ColumnValues::DateTime2(_)
+            | ColumnValues::SmallDateTime(_) => chrono::NaiveDateTime::from_sql(self.val)
+                .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+            ColumnValues::DateTimeOffset(_) => {
+                chrono::DateTime::<chrono::FixedOffset>::from_sql(self.val)
+                    .map(|dt| dt.to_rfc3339())
+            }
+            _ => None,
+        }
+    }
+}
+
+macro_rules! visit_int {
+    ($name:ident, $visit:ident, $t:ty) => {
+        fn $name<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+            // Normalize to i128 first to avoid signed/unsigned ambiguity.
+            let wide: i128 = match self.val {
+                ColumnValues::TinyInt(n) => *n as i128,
+                ColumnValues::SmallInt(n) => *n as i128,
+                ColumnValues::Int(n) => *n as i128,
+                ColumnValues::BigInt(n) => *n as i128,
+                ColumnValues::Bit(b) => *b as i128,
+                _ => return self.unsupported(stringify!($t)),
+            };
+            let v: $t = <$t as ::std::convert::TryFrom<i128>>::try_from(wide).map_err(|_| {
+                <Error as de::Error>::custom(format!(
+                    "value {} out of range for {}",
+                    wide,
+                    stringify!($t)
+                ))
+            })?;
+            visitor.$visit(v)
+        }
+    };
+}
+
+macro_rules! visit_float {
+    ($name:ident, $visit:ident, $t:ty) => {
+        fn $name<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+            let v: $t = match self.val {
+                ColumnValues::Real(n) => *n as $t,
+                ColumnValues::Float(n) => *n as $t,
+                ColumnValues::TinyInt(n) => *n as $t,
+                ColumnValues::SmallInt(n) => *n as $t,
+                ColumnValues::Int(n) => *n as $t,
+                ColumnValues::BigInt(n) => *n as $t,
+                ColumnValues::Money(m) => {
+                    let f: mssql_tds::core::TdsResult<f64> = m.into();
+                    f.map_err(|e| {
+                        <Error as de::Error>::custom(format!("money decode failed: {e:?}"))
+                    })? as $t
+                }
+                ColumnValues::SmallMoney(sm) => (sm.int_val as f64 / 10_000.0) as $t,
+                _ => return self.unsupported(stringify!($t)),
+            };
+            visitor.$visit(v)
+        }
+    };
+}
+
+impl<'de, 'a: 'de> Deserializer<'de> for ColumnValueDeserializer<'a> {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::Null => visitor.visit_unit(),
+            ColumnValues::Bit(b) => visitor.visit_bool(*b),
+            ColumnValues::TinyInt(v) => visitor.visit_u8(*v),
+            ColumnValues::SmallInt(v) => visitor.visit_i16(*v),
+            ColumnValues::Int(v) => visitor.visit_i32(*v),
+            ColumnValues::BigInt(v) => visitor.visit_i64(*v),
+            ColumnValues::Real(v) => visitor.visit_f32(*v),
+            ColumnValues::Float(v) => visitor.visit_f64(*v),
+            ColumnValues::Bytes(b) => visitor.visit_borrowed_bytes(b),
+            ColumnValues::Uuid(u) => visitor.visit_string(u.to_string()),
+            ColumnValues::String(_) | ColumnValues::Xml(_) | ColumnValues::Json(_) => {
+                match self.decoded {
+                    Some(s) => visitor.visit_borrowed_str(s),
+                    None => visitor.visit_borrowed_str(""),
+                }
+            }
+            ColumnValues::Date(_)
+            | ColumnValues::Time(_)
+            | ColumnValues::DateTime(_)
+            | ColumnValues::DateTime2(_)
+            | ColumnValues::SmallDateTime(_)
+            | ColumnValues::DateTimeOffset(_) => {
+                let s = self
+                    .temporal_string()
+                    .ok_or_else(|| Error::Conversion("invalid temporal value".into()))?;
+                visitor.visit_string(s)
+            }
+            ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
+                visitor.visit_string(d.to_string())
+            }
+            ColumnValues::Money(m) => {
+                let f: mssql_tds::core::TdsResult<f64> = m.into();
+                let n = f.map_err(|e| {
+                    <Error as de::Error>::custom(format!("money decode failed: {e:?}"))
+                })?;
+                visitor.visit_f64(n)
+            }
+            ColumnValues::SmallMoney(sm) => visitor.visit_f64(sm.int_val as f64 / 10_000.0),
+            ColumnValues::Vector(_) => Err(Error::Conversion(
+                "ColumnValues::Vector is not supported by serde Deserialize".into(),
+            )),
+        }
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::Bit(b) => visitor.visit_bool(*b),
+            _ => self.unsupported("bool"),
+        }
+    }
+
+    visit_int!(deserialize_i8, visit_i8, i8);
+    visit_int!(deserialize_i16, visit_i16, i16);
+    visit_int!(deserialize_i32, visit_i32, i32);
+    visit_int!(deserialize_i64, visit_i64, i64);
+    visit_int!(deserialize_i128, visit_i128, i128);
+    visit_int!(deserialize_u8, visit_u8, u8);
+    visit_int!(deserialize_u16, visit_u16, u16);
+    visit_int!(deserialize_u32, visit_u32, u32);
+    visit_int!(deserialize_u64, visit_u64, u64);
+    visit_int!(deserialize_u128, visit_u128, u128);
+
+    visit_float!(deserialize_f32, visit_f32, f32);
+    visit_float!(deserialize_f64, visit_f64, f64);
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.decoded {
+            Some(s) => {
+                let mut iter = s.chars();
+                match (iter.next(), iter.next()) {
+                    (Some(c), None) => visitor.visit_char(c),
+                    _ => Err(Error::Conversion(
+                        "cannot deserialize multi-char string as char".into(),
+                    )),
+                }
+            }
+            None => self.unsupported("char"),
+        }
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::String(_) | ColumnValues::Xml(_) | ColumnValues::Json(_) => {
+                match self.decoded {
+                    Some(s) => visitor.visit_borrowed_str(s),
+                    None => visitor.visit_borrowed_str(""),
+                }
+            }
+            ColumnValues::Uuid(u) => visitor.visit_string(u.to_string()),
+            ColumnValues::Date(_)
+            | ColumnValues::Time(_)
+            | ColumnValues::DateTime(_)
+            | ColumnValues::DateTime2(_)
+            | ColumnValues::SmallDateTime(_)
+            | ColumnValues::DateTimeOffset(_) => {
+                let s = self
+                    .temporal_string()
+                    .ok_or_else(|| Error::Conversion("invalid temporal value".into()))?;
+                visitor.visit_string(s)
+            }
+            ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
+                visitor.visit_string(d.to_string())
+            }
+            _ => self.unsupported("&str"),
+        }
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::Bytes(b) => visitor.visit_borrowed_bytes(b),
+            ColumnValues::Uuid(u) => visitor.visit_borrowed_bytes(u.as_bytes()),
+            _ => self.unsupported("bytes"),
+        }
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.val {
+            ColumnValues::Bytes(b) => visitor.visit_byte_buf(b.clone()),
+            ColumnValues::Uuid(u) => visitor.visit_byte_buf(u.as_bytes().to_vec()),
+            _ => self.unsupported("byte buf"),
+        }
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value> {
+        Err(Error::Conversion(
+            "cannot deserialize a column value as a sequence".into(),
+        ))
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(self, _len: usize, visitor: V) -> Result<V::Value> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value> {
+        Err(Error::Conversion(
+            "cannot deserialize a column value as a map".into(),
+        ))
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        // Enums backed by their variant name as a string in the column.
+        visitor.visit_enum(EnumStrAccess { de: self })
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_unit()
+    }
+}
+
+struct EnumStrAccess<'a> {
+    de: ColumnValueDeserializer<'a>,
+}
+
+impl<'de, 'a: 'de> de::EnumAccess<'de> for EnumStrAccess<'a> {
+    type Error = Error;
+    type Variant = UnitVariant;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant)> {
+        let v = seed.deserialize(self.de)?;
+        Ok((v, UnitVariant))
+    }
+}
+
+struct UnitVariant;
+
+impl<'de> de::VariantAccess<'de> for UnitVariant {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, _seed: T) -> Result<T::Value> {
+        Err(Error::Conversion(
+            "newtype enum variants are not supported on column values".into(),
+        ))
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(self, _len: usize, _visitor: V) -> Result<V::Value> {
+        Err(Error::Conversion(
+            "tuple enum variants are not supported on column values".into(),
+        ))
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value> {
+        Err(Error::Conversion(
+            "struct enum variants are not supported on column values".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::column::{Column, ColumnType};
+    use crate::row::RowSchema;
+    use mssql_tds::datatypes::column_values::ColumnValues;
+    use mssql_tds::datatypes::sql_string::SqlString;
+    use serde::Deserialize;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_row(pairs: Vec<(&str, ColumnType, ColumnValues)>) -> Row {
+        let columns: Vec<Column> = pairs
+            .iter()
+            .map(|(n, t, _)| Column::test_column(n, *t, 0))
+            .collect();
+        let values: Vec<ColumnValues> = pairs.into_iter().map(|(_, _, v)| v).collect();
+        let name_map: HashMap<String, usize> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.name().to_string(), i))
+            .collect();
+        let schema = Arc::new(RowSchema { columns, name_map });
+        Row::from_schema(schema, values)
+    }
+
+    fn s(v: &str) -> ColumnValues {
+        ColumnValues::String(SqlString::from_utf8_string(v.into()))
+    }
+
+    #[test]
+    fn deserialize_basic_struct() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct User {
+            id: i64,
+            name: String,
+            active: bool,
+        }
+        let row = make_row(vec![
+            ("id", ColumnType::Int8, ColumnValues::BigInt(42)),
+            ("name", ColumnType::NVarchar, s("alice")),
+            ("active", ColumnType::Bit, ColumnValues::Bit(true)),
+        ]);
+        let u: User = row.deserialize().unwrap();
+        assert_eq!(
+            u,
+            User {
+                id: 42,
+                name: "alice".to_string(),
+                active: true,
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_option_handles_null() {
+        #[derive(Deserialize)]
+        struct R {
+            email: Option<String>,
+            phone: Option<String>,
+        }
+        let row = make_row(vec![
+            ("email", ColumnType::NVarchar, s("a@b")),
+            ("phone", ColumnType::NVarchar, ColumnValues::Null),
+        ]);
+        let v: R = row.deserialize().unwrap();
+        assert_eq!(v.email.as_deref(), Some("a@b"));
+        assert_eq!(v.phone, None);
+    }
+
+    #[test]
+    fn deserialize_widens_integers() {
+        #[derive(Deserialize)]
+        struct R {
+            tiny: i64,
+            small: i64,
+            int_: i64,
+            big: i64,
+        }
+        let row = make_row(vec![
+            ("tiny", ColumnType::Int1, ColumnValues::TinyInt(7)),
+            ("small", ColumnType::Int2, ColumnValues::SmallInt(-3)),
+            ("int_", ColumnType::Int4, ColumnValues::Int(1_000_000)),
+            ("big", ColumnType::Int8, ColumnValues::BigInt(i64::MAX)),
+        ]);
+        let r: R = row.deserialize().unwrap();
+        assert_eq!(r.tiny, 7);
+        assert_eq!(r.small, -3);
+        assert_eq!(r.int_, 1_000_000);
+        assert_eq!(r.big, i64::MAX);
+    }
+
+    #[test]
+    fn deserialize_floats() {
+        #[derive(Deserialize)]
+        struct R {
+            r: f32,
+            f: f64,
+        }
+        let row = make_row(vec![
+            ("r", ColumnType::Float4, ColumnValues::Real(1.5)),
+            (
+                "f",
+                ColumnType::Float8,
+                ColumnValues::Float(std::f64::consts::PI),
+            ),
+        ]);
+        let r: R = row.deserialize().unwrap();
+        assert!((r.r - 1.5).abs() < 1e-6);
+        assert!((r.f - std::f64::consts::PI).abs() < 1e-12);
+    }
+
+    #[test]
+    fn deserialize_uuid_as_string() {
+        #[derive(Deserialize)]
+        struct R {
+            id: String,
+        }
+        let id = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let row = make_row(vec![("id", ColumnType::Guid, ColumnValues::Uuid(id))]);
+        let r: R = row.deserialize().unwrap();
+        assert_eq!(r.id, "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn deserialize_borrowed_str() {
+        #[derive(Deserialize)]
+        struct R<'a> {
+            name: &'a str,
+        }
+        let row = make_row(vec![("name", ColumnType::NVarchar, s("borrowed"))]);
+        let r: R<'_> = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.name, "borrowed");
+    }
+
+    #[test]
+    fn deserialize_temporal_as_string() {
+        #[derive(Deserialize)]
+        struct R {
+            d: String,
+        }
+        // SqlDate::create takes days-since-0001-01-01. Pick a known date.
+        let date_val = mssql_tds::datatypes::column_values::SqlDate::create(737_790).unwrap();
+        let row = make_row(vec![("d", ColumnType::Date, ColumnValues::Date(date_val))]);
+        let r: R = row.deserialize().unwrap();
+        assert_eq!(r.d.len(), 10);
+        assert_eq!(&r.d[4..5], "-");
+        assert_eq!(&r.d[7..8], "-");
+    }
+
+    #[test]
+    fn deserialize_missing_column_field_errors() {
+        #[derive(Deserialize)]
+        #[allow(dead_code)]
+        struct R {
+            a: i32,
+            b: i32,
+        }
+        let row = make_row(vec![("a", ColumnType::Int4, ColumnValues::Int(1))]);
+        let res: Result<R> = row.deserialize();
+        assert!(res.is_err(), "expected missing-field error, got Ok");
+    }
+
+    #[test]
+    fn deserialize_tuple_positional() {
+        let row = make_row(vec![
+            ("x", ColumnType::Int4, ColumnValues::Int(1)),
+            ("y", ColumnType::NVarchar, s("two")),
+            ("z", ColumnType::Bit, ColumnValues::Bit(false)),
+        ]);
+        let t: (i32, String, bool) = row.deserialize().unwrap();
+        assert_eq!(t, (1, "two".to_string(), false));
+    }
+
+    #[test]
+    fn deserialize_extra_columns_ignored() {
+        // Struct asks for only `a`, row has `a` and `b`. Should succeed.
+        #[derive(Deserialize)]
+        struct R {
+            a: i32,
+        }
+        let row = make_row(vec![
+            ("a", ColumnType::Int4, ColumnValues::Int(11)),
+            ("b", ColumnType::Int4, ColumnValues::Int(22)),
+        ]);
+        let r: R = row.deserialize().unwrap();
+        assert_eq!(r.a, 11);
+    }
+
+    #[test]
+    fn deserialize_renamed_field() {
+        #[derive(Deserialize)]
+        struct R {
+            #[serde(rename = "FullName")]
+            full_name: String,
+        }
+        let row = make_row(vec![("FullName", ColumnType::NVarchar, s("Ada Lovelace"))]);
+        let r: R = row.deserialize().unwrap();
+        assert_eq!(r.full_name, "Ada Lovelace");
+    }
+}


### PR DESCRIPTION
Closes #57.

## What

Adds row → struct mapping via `serde`, gated behind a new `serde` cargo feature (off by default).

```rust
use serde::Deserialize;
use mssql_tiberius_bridge::Row;

#[derive(Deserialize)]
struct User {
    id: i64,
    name: String,
    email: Option<String>,
}

let users: Vec<User> = client.query("SELECT id, name, email FROM users", &[])
    .await?
    .into_first_result()
    .into_iter()
    .map(Row::deserialize)
    .collect::<mssql_tiberius_bridge::Result<Vec<_>>>()?;
```

## API

* `Row::deserialize<T: DeserializeOwned>(self) -> Result<T>` — consuming, owned.
* `Row::deserialize_borrowed<'de, T: Deserialize<'de>>(&'de self) -> Result<T>` — for `&str` / `&[u8]` fields that borrow from the row's pre-decoded UTF-8 cache.
* New module `crate::serde_de` exposing `RowDeserializer` for advanced use.

## Type mapping

| TDS column type                          | Visited as                          |
|------------------------------------------|-------------------------------------|
| `bit`                                    | `bool`                              |
| `tinyint` / `smallint` / `int` / `bigint`| widening integer (`u8` … `i64`/`i128`) |
| `real` / `float`                         | `f32` / `f64`                       |
| `money` / `smallmoney`                   | `f64`                               |
| `nvarchar` / `varchar` / `text` / `xml` / `json` | borrowed `&str` (UTF-8) |
| `varbinary` / `binary` / `image`         | borrowed `&[u8]`                    |
| `uniqueidentifier`                       | `&str` (lowercase hyphenated UUID)  |
| `date` / `time` / `datetime` / `datetime2` / `datetimeoffset` / `smalldatetime` | ISO-8601 `String` |
| `decimal` / `numeric`                    | `String` (`Display` of `DecimalParts`) |
| `NULL`                                   | `None` when typed as `Option<T>` (else unit) |

Integer widening uses `TryFrom<i128>` so overflow surfaces as a `Conversion` error rather than a silent truncation.

Field-name matching is **exact-case** (same lookup as `Row::get`); use `#[serde(rename = "Name")]` to map to a column whose name doesn't match the Rust identifier.

## Implementation

* `impl serde::de::Error for crate::Error` via the existing `Conversion` variant — keeps the public error surface unchanged.
* `RowDeserializer` exposes the row as a `MapAccess` (struct/map) or `SeqAccess` (tuple/positional). Extra columns are silently ignored when serde calls `deserialize_struct` and the field set is closed; missing struct fields surface as the standard serde "missing field" error.
* `ColumnValueDeserializer` handles per-cell type dispatch and re-uses `Row::decoded_str_at(idx)` (a new `pub(crate)` accessor) so no new UTF-8 decode allocations happen.
* `Vector` is rejected (no canonical serde mapping yet).

## Tests

11 new unit tests (`src/serde_de.rs::tests`):

* `deserialize_basic_struct` — i64 / String / bool
* `deserialize_option_handles_null` — `Option<String>` with NULL and value
* `deserialize_widens_integers` — TinyInt/SmallInt/Int/BigInt → i64
* `deserialize_floats` — Real → f32, Float → f64
* `deserialize_uuid_as_string`
* `deserialize_borrowed_str` — `&'de str` field via `deserialize_borrowed`
* `deserialize_temporal_as_string` — date column → ISO-8601
* `deserialize_missing_column_field_errors` — required field absent
* `deserialize_tuple_positional` — `(i32, String, bool)` from row by position
* `deserialize_extra_columns_ignored` — struct asks subset of columns
* `deserialize_renamed_field` — `#[serde(rename)]`

CI: added `cargo test --lib --features serde` and a parallel doc-test step so the new module is exercised on every PR (the existing default-features step keeps coverage of the core path).

## Compatibility / scope

* Off-by-default feature; no impact on existing builds.
* No changes to public types in `crate::row` other than two new `#[cfg(feature = "serde")]` methods on `Row`.
* `serde_json::Value` for `JSON` columns: the deserializer hands the visitor the raw JSON text. Users who want a parsed `Value` can keep using `Row::get::<serde_json::Value, _>(...)` (already works via `FromSql`) — see #57 for follow-up if a richer mapping is wanted.
