### PR TITLE
chore(tests): inline format args in ssrp test

### DIFF
--- a/tests/ssrp.rs
+++ b/tests/ssrp.rs
@@ -43,5 +43,5 @@ async fn ssrp_named_instance_connect() {
         .into_first_result();
     let server_name = row[0].get::<&str, _>(0usize);
     assert!(server_name.is_some());
-    eprintln!("SSRP-resolved @@SERVERNAME: {:?}", server_name);
+    eprintln!("SSRP-resolved @@SERVERNAME: {server_name:?}");
 }


### PR DESCRIPTION
Trivial: inline the format arg to silence clippy::uninlined_format_args caught by newer local toolchain. CI was unaffected.