### PR TITLE
docs(triage): inline Bridge status column in every section table

### DIFF
--- a/docs/tiberius-issues-triage.md
+++ b/docs/tiberius-issues-triage.md
@@ -24,181 +24,181 @@ This document categorizes every open issue in `prisma/tiberius` to determine whi
 
 These are bugs in tiberius's TDS implementation. The bridge uses `mssql-tds`, an entirely separate parser, so most are **not** present.
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 418 | Display impl for PacketSize/Database EnvChange shows old/new swapped | 🟢 | tiberius-internal log formatting bug. mssql-tds has its own EnvChange impl. |
-| 410 | BCP failure when DATE column precedes TIME column | 🟢 | tiberius-only BCP encoder bug. Bridge has no `bulk_insert` yet anyway. |
-| 368 | Negative Numeric Floats sign issue (`-17.-80`) | 🟡 | **Repro**: did we already fix this? Numeric Display in `DecimalParts`. Worth a regression test. |
-| 316 | Panic reading datetime field with date < 1900 (overflow in `time` feature) | 🟡 | **Repro**: try with `chrono`. mssql-tds may have same overflow. |
-| 325 | UTF-16 error on broken characters | 🟡 | **Repro**: check `to_utf8_string` on `SqlString` for replacement-char fallback. |
-| 322 | Bulk insert large varchar/nvarchar fails (BCP colid 8) | 🟢 | tiberius BCP-only; bridge has no bulk_insert. |
-| 358 | `bulk_insert` does not support Money MS SQL data type | 🟢 | tiberius-only. Money/SmallMoney *are* readable in bridge. |
-| 370 | (n/a placeholder) | — | — |
-| 211 | Panic from `try_get` (unwrap path) | 🟡 | **Repro**: bridge `Row::try_get` shouldn't panic on type mismatch. |
-| 263 | Cannot interpret `I16(None)` as `i32` | 🟡 | **Repro**: bridge `FromSql for i32` — does it accept SmallInt(None)? Likely improvement. |
-| 226 | Performance: handling buffers in `plp.rs` | 🟢 | tiberius-only PLP decoder; mssql-tds is separate. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 418 | Display impl for PacketSize/Database EnvChange shows old/new swapped | 🟢 | — | tiberius-internal log formatting bug. mssql-tds has its own EnvChange impl. |
+| 410 | BCP failure when DATE column precedes TIME column | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | tiberius-only BCP encoder bug. Bridge has no `bulk_insert` yet anyway. |
+| 368 | Negative Numeric Floats sign issue (`-17.-80`) | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: did we already fix this? Numeric Display in `DecimalParts`. Worth a regression test. |
+| 316 | Panic reading datetime field with date < 1900 (overflow in `time` feature) | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: try with `chrono`. mssql-tds may have same overflow. |
+| 325 | UTF-16 error on broken characters | 🟡 | tracked in [#90](../../issues/90) | **Repro**: check `to_utf8_string` on `SqlString` for replacement-char fallback. |
+| 322 | Bulk insert large varchar/nvarchar fails (BCP colid 8) | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | tiberius BCP-only; bridge has no bulk_insert. |
+| 358 | `bulk_insert` does not support Money MS SQL data type | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | tiberius-only. Money/SmallMoney *are* readable in bridge. |
+| 370 | (n/a placeholder) | — | — | — |
+| 211 | Panic from `try_get` (unwrap path) | ✅ | [#42](../../issues/42) (PR [#43](../../pull/43)) | **Repro**: bridge `Row::try_get` shouldn't panic on type mismatch. |
+| 263 | Cannot interpret `I16(None)` as `i32` | ⚪ | bridge `FromSql for i32` already widens from `SmallInt`/`TinyInt`; null via `Option<i32>` | **Repro**: bridge `FromSql for i32` — does it accept SmallInt(None)? Likely improvement. |
+| 226 | Performance: handling buffers in `plp.rs` | 🟢 | — | tiberius-only PLP decoder; mssql-tds is separate. |
 
 ## B. TLS / Encryption Issues
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 412 | TDS 8.0 and "Strict" encryption option | 🔵 | Feature gap. mssql-tds may already do TDS 7.4 encryption; check if it speaks 8.0/Strict. File as feature. |
-| 412 | (same) | — | — |
-| 327 | `UnsupportedCertVersion` with rustls | 🟢 | tiberius-rustls bug. Bridge uses native-tls. |
-| 320 | TLS handshake stalls when `EncryptionLevel::Off` | 🟡 | **Repro**: connect with `EncryptionLevel::Off` in bridge — does it skip handshake? |
-| 305 | Unencrypted traffic despite `encrypt=true` due to TLS feature flags disablement | 🟢 | tiberius feature-flag config bug. Bridge's encryption is unconditional. |
-| 364 | macOS 15 + SQL Server 2014 doesn't work (rustls/vendored-openssl) | 🟡 | **Repro**: try bridge against SQL Server 2014. native-tls may behave differently. |
-| 274 | TLS handshake EOF | 🟡 | **Repro**: similar — try basic connect with bridge against the user's reported config. |
-| 323 | Failing to connect with TLS (rustls compile errors) | 🟢 | tiberius rustls feature-set issue; N/A. |
-| 218 | tiberius 0.9 keep crashing on macOS | 🟢 | Old version; tiberius-internal. |
-| 340 | Setting `HostNameInCertificate` property | 🔵 | Feature: bridge could expose `Config::host_name_in_certificate`. |
-| 224 | `danger_accept_invalid_hostnames` + `danger_accept_invalid_certs` | 🔵 | Bridge already has `trust_cert` (skip verify). Hostname-only skip is a separate variant. |
-| 381 | openssl support (TLS 1.0 for old SQL Server) | 🔵 | mssql-tds uses native-tls (which on macOS uses SecureTransport, on Linux uses openssl). May already support TLS 1.0. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 412 | TDS 8.0 and "Strict" encryption option | ✅ | [#62](../../issues/62) — Strict encryption wired | Feature gap. mssql-tds may already do TDS 7.4 encryption; check if it speaks 8.0/Strict. File as feature. |
+| 412 | (same) | ✅ | [#62](../../issues/62) — Strict encryption wired | — |
+| 327 | `UnsupportedCertVersion` with rustls | 🟢 | — | tiberius-rustls bug. Bridge uses native-tls. |
+| 320 | TLS handshake stalls when `EncryptionLevel::Off` | 🟡 | tracked in [#89](../../issues/89) | **Repro**: connect with `EncryptionLevel::Off` in bridge — does it skip handshake? |
+| 305 | Unencrypted traffic despite `encrypt=true` due to TLS feature flags disablement | 🟢 | — | tiberius feature-flag config bug. Bridge's encryption is unconditional. |
+| 364 | macOS 15 + SQL Server 2014 doesn't work (rustls/vendored-openssl) | ⚪ | out-of-scope (SQL Server 2014 — unsupported) | **Repro**: try bridge against SQL Server 2014. native-tls may behave differently. |
+| 274 | TLS handshake EOF | 🟡 | tracked in [#89](../../issues/89) | **Repro**: similar — try basic connect with bridge against the user's reported config. |
+| 323 | Failing to connect with TLS (rustls compile errors) | 🟢 | — | tiberius rustls feature-set issue; N/A. |
+| 218 | tiberius 0.9 keep crashing on macOS | ⚪ | out-of-scope (old tiberius version) | Old version; tiberius-internal. |
+| 340 | Setting `HostNameInCertificate` property | ✅ | [#47](../../issues/47) (PR [#50](../../pull/50)) — `Config::host_name_in_certificate` | Feature: bridge could expose `Config::host_name_in_certificate`. |
+| 224 | `danger_accept_invalid_hostnames` + `danger_accept_invalid_certs` | 🟡 | tracked in [#48](../../issues/48) — blocked on mssql-tds | Bridge already has `trust_cert` (skip verify). Hostname-only skip is a separate variant. |
+| 381 | openssl support (TLS 1.0 for old SQL Server) | ⚪ | [#70](../../issues/70) closed wontfix — only legacy SQL Server (≤2012) needs TLS<1.2 | mssql-tds uses native-tls (which on macOS uses SecureTransport, on Linux uses openssl). May already support TLS 1.0. |
 
 ## C. Authentication
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 407 | sspi-rs for SSPI NTLM on Linux/macOS without Kerberos | 🔵 | Bridge currently does Kerberos via libgssapi dlopen on Linux. NTLM-on-Linux is a real gap. |
-| 343 | Panic in libgssapi when using Integrated Security (Rust 1.78) | 🟡 | **Repro**: bridge's libgssapi version — verify it includes the fix referenced (estokes/libgssapi#23). |
-| 283 | Build problems with `Auth::Integrated` on CI | 🟢 | tiberius-feature build issue. Bridge gates differently. |
-| 276 | GSS-NTLMSSP instead of Kerberos on Linux | 🔵 | Same as 407 — NTLM-via-GSSAPI. |
-| 175 | Is Azure SQL/AAD supported? | ✅ | Already done — bridge has `AuthMethod::aad_token` (PR #26). |
-| 97 | WindowsAuth should be available in Linux | 🔵 | Same theme as #407/#276. Bridge uses libgssapi for Kerberos. NTLM gap. |
-| 333 | Connection failure with special-character password | 🟡 | **Repro**: try special chars in `AuthMethod::sql_server`. Likely fine since we don't ADO-parse. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 407 | sspi-rs for SSPI NTLM on Linux/macOS without Kerberos | 🟡 | tracked in [#66](../../issues/66) | Bridge currently does Kerberos via libgssapi dlopen on Linux. NTLM-on-Linux is a real gap. |
+| 343 | Panic in libgssapi when using Integrated Security (Rust 1.78) | ⚪ | bridge libgssapi already includes upstream fix | **Repro**: bridge's libgssapi version — verify it includes the fix referenced (estokes/libgssapi#23). |
+| 283 | Build problems with `Auth::Integrated` on CI | 🟢 | — | tiberius-feature build issue. Bridge gates differently. |
+| 276 | GSS-NTLMSSP instead of Kerberos on Linux | 🟡 | tracked in [#66](../../issues/66) | Same as 407 — NTLM-via-GSSAPI. |
+| 175 | Is Azure SQL/AAD supported? | ✅ | `AuthMethod::aad_token` (PR [#26](../../pull/26)) | Already done — bridge has `AuthMethod::aad_token` (PR #26). |
+| 97 | WindowsAuth should be available in Linux | 🟡 | tracked in [#66](../../issues/66) | Same theme as #407/#276. Bridge uses libgssapi for Kerberos. NTLM gap. |
+| 333 | Connection failure with special-character password | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: try special chars in `AuthMethod::sql_server`. Likely fine since we don't ADO-parse. |
 
 ## D. Bulk Insert / BCP (entire feature missing in bridge)
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 410 | BCP date+time column-order failure | 🟢 | (covered above) |
-| 358 | Money in bulk_insert | 🟢 | (covered above) |
-| 352 | NTEXT bulk insert example | 🟢 | how-to; bridge has no bulk_insert. |
-| 322 | Large varchar/nvarchar bulk insert | 🟢 | (covered above) |
-| 319 | Insert into TEXT column | 🟢 | how-to; bridge can `INSERT` via `query`/`execute`. |
-| 311 | Bulk Insert: Allow column names | 🔵 | Feature for when bridge implements bulk_insert. |
-| 307 | Bulk insert with datetime field | 🟢 | how-to / tiberius-specific. |
-| 302 | Bulk Copy Options | 🔵 | Feature for future bulk_insert. |
-| 373 | Date issue in bulk insert (target schema) | 🟢 | tiberius-only. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 410 | BCP date+time column-order failure | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | (covered above) |
+| 358 | Money in bulk_insert | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | (covered above) |
+| 352 | NTEXT bulk insert example | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | how-to; bridge has no bulk_insert. |
+| 322 | Large varchar/nvarchar bulk insert | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | (covered above) |
+| 319 | Insert into TEXT column | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | how-to; bridge can `INSERT` via `query`/`execute`. |
+| 311 | Bulk Insert: Allow column names | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | Feature for when bridge implements bulk_insert. |
+| 307 | Bulk insert with datetime field | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | how-to / tiberius-specific. |
+| 302 | Bulk Copy Options | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | Feature for future bulk_insert. |
+| 373 | Date issue in bulk insert (target schema) | ✅ | via [#53](../../issues/53) (PR [#84](../../pull/84)) | tiberius-only. |
 
-> **Bridge gap**: `bulk_insert` is not yet implemented. All BCP-related issues map to a single roadmap item. ⇒ File one tracking issue: "Implement `Client::bulk_insert` (BCP)" referencing this cluster.
+> **✅ Bridge update**: `Client::bulk_insert` (BCP) shipped in [#53](../../issues/53) via PR [#84](../../pull/84) and [PR #86](../../pull/86) (Apache Arrow `RecordBatch` input under the `arrow` feature). All BCP-related rows above are now covered.
 
 ## E. Type Conversion / `FromSql` / `ToSql` / `IntoSql`
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 401 | Implement `IntoSql` for `rust_decimal` | 🟡 | **Check**: bridge's `ToSql for Decimal`. Probably already has. |
-| 277 | `IntoSql` impl missing for `time` crate | 🔵 | Bridge added chrono ToSql in PR #23; `time` crate is a separate gap. |
-| 244 | `impl IntoSql<'a>` in `.bind()` method | ⚪ | Bridge has no `Query::bind` builder; N/A. |
-| 257 | Can't get `geography` type | 🟡 | **Repro**: bridge `ColumnValues` — does it have a Geography variant? Likely no. |
-| 354 | jiff crate support | 🔵 | Feature. Mirror chrono/time impls. |
-| 277 | (dup) | — | — |
-| 401 | (dup) | — | — |
-| 169 | Owned variants on `FromSql` for `String`/`Vec` | 🔵 | **Check**: bridge `FromSql<String>` / `FromSql<Vec<u8>>`. |
-| 367 | `sendStringParametersAsUnicode` connection property | 🔵 | Feature: control NVARCHAR-vs-VARCHAR encoding for string params. |
-| 334 | Why tinyint converted to u8? | ⚪ | Tiberius design — TDS TinyInt is unsigned 1-byte. Not a bug. |
-| 216 | Distinguishing `Intn` for bigint vs int | ⚪ | how-to / FromSql usage. |
-| 219 | Case insensitive `row.get()` | 🔵 | Feature gap. **Check** if bridge `Row::get(name)` is case-sensitive. Probably yes. |
-| 221 | f64::NAN insert into decimal column | 🟡 | **Repro**: send NaN as `f64` param to bridge — should error gracefully, not corrupt protocol. |
-| 282 | Binding string adds quotation marks (with proc) | 🟡 | **Repro**: call a SP via bridge with a `&str` param. |
-| 278 | Dynamic interaction with query results | ⚪ | how-to / design discussion. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 401 | Implement `IntoSql` for `rust_decimal` | 🟡 | tracked in [#87](../../issues/87) — `ToSql for rust_decimal::Decimal` missing | **Check**: bridge's `ToSql for Decimal`. Probably already has. |
+| 277 | `IntoSql` impl missing for `time` crate | ✅ | [#67](../../issues/67) — `time` crate `ToSql` | Bridge added chrono ToSql in PR #23; `time` crate is a separate gap. |
+| 244 | `impl IntoSql<'a>` in `.bind()` method | ⚪ | — | Bridge has no `Query::bind` builder; N/A. |
+| 257 | Can't get `geography` type | 🟡 | tracked in [#69](../../issues/69) | **Repro**: bridge `ColumnValues` — does it have a Geography variant? Likely no. |
+| 354 | jiff crate support | ✅ | [#68](../../issues/68) — `jiff` support | Feature. Mirror chrono/time impls. |
+| 277 | (dup) | ✅ | [#67](../../issues/67) — `time` crate `ToSql` | — |
+| 401 | (dup) | 🟡 | tracked in [#87](../../issues/87) — `ToSql for rust_decimal::Decimal` missing | — |
+| 169 | Owned variants on `FromSql` for `String`/`Vec` | ✅ | [#40](../../issues/40) (PR [#43](../../pull/43)) | **Check**: bridge `FromSql<String>` / `FromSql<Vec<u8>>`. |
+| 367 | `sendStringParametersAsUnicode` connection property | ✅ | [#49](../../issues/49) (PR [#50](../../pull/50)) | Feature: control NVARCHAR-vs-VARCHAR encoding for string params. |
+| 334 | Why tinyint converted to u8? | ⚪ | — | Tiberius design — TDS TinyInt is unsigned 1-byte. Not a bug. |
+| 216 | Distinguishing `Intn` for bigint vs int | ⚪ | — | how-to / FromSql usage. |
+| 219 | Case insensitive `row.get()` | ✅ | [#41](../../issues/41) (PR [#43](../../pull/43)) — `get_ci`/`try_get_ci` | Feature gap. **Check** if bridge `Row::get(name)` is case-sensitive. Probably yes. |
+| 221 | f64::NAN insert into decimal column | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: send NaN as `f64` param to bridge — should error gracefully, not corrupt protocol. |
+| 282 | Binding string adds quotation marks (with proc) | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: call a SP via bridge with a `&str` param. |
+| 278 | Dynamic interaction with query results | ⚪ | — | how-to / design discussion. |
 
 ## F. Connectivity / Connection Setup
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 414 | Client hostname in `LoginMessage` | 🔵 | **Check**: does bridge send a real hostname in Login7? It likely uses `localhost`. |
-| 386 | smol 2.0 incompat with `sql-browser-smol` | 🟢 | tiberius-runtime. Bridge is tokio-only. |
-| 360 | Timeout connecting over VPN | ⚪ | Diagnostic / network. |
-| 345 | Dynamic ports in Docker | ⚪ | Use SSRP / instance_name. Bridge already supports SSRP (PR #27). |
-| 313 | "Key-value pairs must be separated by a `;`" parsing | 🟢 | tiberius ADO-string parser. Bridge has its own `Config` builder. |
-| 329 | Update `tokio_rustls` 0.24 → 0.25 | 🟢 | tiberius dep. N/A. |
-| 337 | MultiSubnetFailover support | 🔵 | Feature. mssql-tds may have routing redirect; MSF is separate. |
-| 348 | Send ReadOnlyIntent (already merged in tiberius PR #297) | ✅ | Bridge already has `Config::readonly` (PR #24). |
-| 335 | Read-only routing examples | ⚪ | how-to. |
-| 375 | azure-sql-edge on macOS hangs | 🟡 | **Repro**: try connecting bridge to an azure-sql-edge container. |
-| 198 | Check if TCP connection is alive | 🔵 | Feature: `Client::ping` or `is_connected`. |
-| 299 | Reset connection (`sp_reset_connection`) | 🔵 | Feature for pooling. |
-| 301 | How do I call `ping`? | ⚪ | how-to. |
-| 131 | Named pipes support | 🔵 | Feature. mssql-tds may not support named pipes. |
-| 53  | Other connection methods than TCP | 🔵 | Same theme. |
-| 125 | COUNT() fails on GCP | ⚪ | Environment issue. |
-| 70  | diesel + tiberius | ⚪ | Out of scope. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 414 | Client hostname in `LoginMessage` | ✅ | [#46](../../issues/46) (PR [#50](../../pull/50)) — `Config::client_name` | **Check**: does bridge send a real hostname in Login7? It likely uses `localhost`. |
+| 386 | smol 2.0 incompat with `sql-browser-smol` | 🟢 | — | tiberius-runtime. Bridge is tokio-only. |
+| 360 | Timeout connecting over VPN | ⚪ | — | Diagnostic / network. |
+| 345 | Dynamic ports in Docker | ✅ | SSRP supported (PR [#27](../../pull/27)) | Use SSRP / instance_name. Bridge already supports SSRP (PR #27). |
+| 313 | "Key-value pairs must be separated by a `;`" parsing | 🟢 | — | tiberius ADO-string parser. Bridge has its own `Config` builder. |
+| 329 | Update `tokio_rustls` 0.24 → 0.25 | 🟢 | — | tiberius dep. N/A. |
+| 337 | MultiSubnetFailover support | ✅ | [#61](../../issues/61) — MultiSubnetFailover | Feature. mssql-tds may have routing redirect; MSF is separate. |
+| 348 | Send ReadOnlyIntent (already merged in tiberius PR #297) | ✅ | `Config::readonly` (PR [#24](../../pull/24)) | Bridge already has `Config::readonly` (PR #24). |
+| 335 | Read-only routing examples | ⚪ | — | how-to. |
+| 375 | azure-sql-edge on macOS hangs | ⚪ | environment-specific (azure-sql-edge on macOS) | **Repro**: try connecting bridge to an azure-sql-edge container. |
+| 198 | Check if TCP connection is alive | ✅ | [#44](../../issues/44) (PR [#45](../../pull/45)) — `Client::ping()` | Feature: `Client::ping` or `is_connected`. |
+| 299 | Reset connection (`sp_reset_connection`) | 🟡 | `ping()` shipped via [#44](../../issues/44); `reset_session()` tracked in [#52](../../issues/52) | Feature for pooling. |
+| 301 | How do I call `ping`? | ✅ | [#44](../../issues/44) — `Client::ping()` | how-to. |
+| 131 | Named pipes support | ✅ | [#60](../../issues/60) — Named pipe transport | Feature. mssql-tds may not support named pipes. |
+| 53 | Other connection methods than TCP | ✅ | [#60](../../issues/60) — Named pipe transport | Same theme. |
+| 125 | COUNT() fails on GCP | ⚪ | — | Environment issue. |
+| 70 | diesel + tiberius | ⚪ | — | Out of scope. |
 
 ## G. API Surface / Ergonomics
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 404 | Implement `Debug` for `ToSql` | 🔵 | Trait surface improvement. |
-| 402 | Implement `Eq` for `Row` and `TokenRow` | 🔵 | For test asserts. |
-| 397 | Expose `BaseMetaDataColumn` & `TypeInfo` | 🔵 | Bridge's `Column` already exposes type/precision/scale to some extent — verify completeness. |
-| 403 | `BaseMetaDataColumn` does not retrieve Identity flag | 🔵 | **Check**: bridge's column metadata — does it carry IDENTITY/nullable/size? |
-| 217 | Column nullable/size/scale enhancement | 🔵 | Same theme. |
-| 383 | Constructing a `Row` for tests | 🔵 | Bridge `Row::from_schema` is `pub` already; verify usable for tests. |
-| 262 | Make `QueryIdx` public | 🔵 | **Check**: bridge has `ColumnIndex` trait — public? |
-| 258 | How to write wrapper for try_get? | ⚪ | how-to (related to #262). |
-| 336 | `Config::trust_cert_ca` should take `Into<PathBuf>` | 🔵 | Bridge already added `trust_cert_ca` (PR #22) — check signature. |
-| 382 | Raw identifier prefixes (r#) should be ignored | 🔵 | `IntoRow`/derive macros — bridge has none yet. |
-| 30  | Statements (prepared) | 🔵 | Feature: prepared statements. mssql-tds may support `sp_prepare`/`sp_execute`. |
-| 28  | Transactions | 🔵 | Feature: high-level Transaction wrapper. |
-| 115 | Add Serde (de)serialization | 🔵 | Feature: `Row` ⇒ struct via serde. |
-| 54  | Column Encryption (CEK) | 🔵 | Large feature. |
-| 289 | ServiceBroker / SqlDependency | 🔵 | Large feature. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 404 | Implement `Debug` for `ToSql` | ✅ | [#64](../../issues/64) — `Debug` for `ToSql` | Trait surface improvement. |
+| 402 | Implement `Eq` for `Row` and `TokenRow` | ✅ | [#65](../../issues/65) — `PartialEq`/`Eq` for `Row` | For test asserts. |
+| 397 | Expose `BaseMetaDataColumn` & `TypeInfo` | ✅ | [#63](../../issues/63) — column metadata | Bridge's `Column` already exposes type/precision/scale to some extent — verify completeness. |
+| 403 | `BaseMetaDataColumn` does not retrieve Identity flag | ✅ | [#63](../../issues/63) — column metadata | **Check**: bridge's column metadata — does it carry IDENTITY/nullable/size? |
+| 217 | Column nullable/size/scale enhancement | ✅ | [#63](../../issues/63) — column metadata | Same theme. |
+| 383 | Constructing a `Row` for tests | 🔵 | — | Bridge `Row::from_schema` is `pub` already; verify usable for tests. |
+| 262 | Make `QueryIdx` public | ✅ | [#39](../../issues/39) (PR [#43](../../pull/43)) — `ColumnIndex` public | **Check**: bridge has `ColumnIndex` trait — public? |
+| 258 | How to write wrapper for try_get? | ⚪ | — | how-to (related to #262). |
+| 336 | `Config::trust_cert_ca` should take `Into<PathBuf>` | ✅ | `Config::trust_cert_ca` exists (PR [#22](../../pull/22)) | Bridge already added `trust_cert_ca` (PR #22) — check signature. |
+| 382 | Raw identifier prefixes (r#) should be ignored | ⚪ | N/A — bridge has no `IntoRow` derive macro | `IntoRow`/derive macros — bridge has none yet. |
+| 30 | Statements (prepared) | 🟡 | tracked in [#56](../../issues/56) — Prepared Statements | Feature: prepared statements. mssql-tds may support `sp_prepare`/`sp_execute`. |
+| 28 | Transactions | 🟡 | tracked in [#55](../../issues/55) — Transactions API | Feature: high-level Transaction wrapper. |
+| 115 | Add Serde (de)serialization | ✅ | [#57](../../issues/57) (PR [#82](../../pull/82)) — Serde row deserialization | Feature: `Row` ⇒ struct via serde. |
+| 54 | Column Encryption (CEK) | 🟡 | tracked in [#58](../../issues/58) — Always Encrypted (CEK) | Large feature. |
+| 289 | ServiceBroker / SqlDependency | 🟡 | tracked in [#59](../../issues/59) — Service Broker | Large feature. |
 
 ## H. Streaming / Query Results
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 380 | `QueryStream::into_results` doesn't return correct number | 🟡 | **Repro**: bridge `QueryResult::into_results` — empty SELECTs preserved? |
-| 371 | QueryStream returns 1 row, ends with more remaining | 🟡 | **Repro**: bridge has streaming via `into_row_stream` (PR #29). |
-| 365 | Cannot return `RowStream` from a function (lifetime tied to connection) | 🔵 | Bridge has same architecture; design issue. Could be addressed via owned stream. |
-| 79  | Cancel safety on futures | 🔵 | Bridge inherits this from mssql-tds — needs investigation. |
-| 300 | Cancel is not safe (tokio::time::timeout corrupts state) | 🟡 | **Repro**: timeout a `client.simple_query` and re-use. |
-| 160 | `rows_affected` length incorrect when table has trigger | 🟡 | **Repro**: bridge's `ExecuteResult::rows_affected`. |
-| 157 | "IN" prepared statement | ⚪ | how-to (TDS doesn't support array params). |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 380 | `QueryStream::into_results` doesn't return correct number | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: bridge `QueryResult::into_results` — empty SELECTs preserved? |
+| 371 | QueryStream returns 1 row, ends with more remaining | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: bridge has streaming via `into_row_stream` (PR #29). |
+| 365 | Cannot return `RowStream` from a function (lifetime tied to connection) | 🔵 | — | Bridge has same architecture; design issue. Could be addressed via owned stream. |
+| 79 | Cancel safety on futures | 🟡 | tracked in [#88](../../issues/88) — cancel-safety audit | Bridge inherits this from mssql-tds — needs investigation. |
+| 300 | Cancel is not safe (tokio::time::timeout corrupts state) | 🟡 | tracked in [#88](../../issues/88) — cancel-safety audit | **Repro**: timeout a `client.simple_query` and re-use. |
+| 160 | `rows_affected` length incorrect when table has trigger | ✅ | regression test in PR [#51](../../pull/51) | **Repro**: bridge's `ExecuteResult::rows_affected`. |
+| 157 | "IN" prepared statement | ⚪ | — | how-to (TDS doesn't support array params). |
 
 ## I. Logging / Diagnostics
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 281 | Opt out of INFO level logs | ⚪ | tracing-subscriber filter, user-side. Document. |
-| 332 | How to close these logs | ⚪ | Same. |
-| 321 | Repo status | ⚪ | meta. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 281 | Opt out of INFO level logs | ⚪ | — | tracing-subscriber filter, user-side. Document. |
+| 332 | How to close these logs | ⚪ | — | Same. |
+| 321 | Repo status | ⚪ | — | meta. |
 
 ## J. Documentation / How-To
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 377 | Extract date using `get` | ⚪ | how-to. |
-| 275 | How to use stored procedures | ⚪ | how-to. |
-| 310 | CREATE SCHEMA only works in `simple_query` | ⚪ | TDS RPC vs SQLBatch difference. Document. |
-| 236 | CREATE FUNCTION error | ⚪ | how-to / SQL syntax. |
-| 399 | CREATE VIEW error | ⚪ | how-to. |
-| 101 | More examples | ⚪ | docs. |
-| 344 | SQL Server 2000 invalid token | ⚪ | unsupported version. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 377 | Extract date using `get` | ⚪ | — | how-to. |
+| 275 | How to use stored procedures | ⚪ | — | how-to. |
+| 310 | CREATE SCHEMA only works in `simple_query` | ⚪ | — | TDS RPC vs SQLBatch difference. Document. |
+| 236 | CREATE FUNCTION error | ⚪ | — | how-to / SQL syntax. |
+| 399 | CREATE VIEW error | ⚪ | — | how-to. |
+| 101 | More examples | ⚪ | — | docs. |
+| 344 | SQL Server 2000 invalid token | ⚪ | out-of-scope (SQL Server 2000 — unsupported) | unsupported version. |
 
 ## K. Performance
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 294 | tiberius slower than odbc-api / C# | 🟡 | **Benchmark**: bridge vs tiberius vs ODBC. |
-| 226 | plp.rs buffer handling perf | 🟢 | tiberius-internal. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 294 | tiberius slower than odbc-api / C# | 🟡 | — | **Benchmark**: bridge vs tiberius vs ODBC. |
+| 226 | plp.rs buffer handling perf | 🟢 | — | tiberius-internal. |
 
 ## L. Build / Dependency / Security Advisories
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 417 | `cargo audit` fails on rustls-webpki RUSTSEC-2026-0098/9/0104 | 🟡 | **Check**: run `cargo audit` on bridge. mssql-tds uses native-tls so likely clean. |
-| 329 | Update tokio_rustls 0.24→0.25 | 🟢 | tiberius dep. |
-| 323 | TLS compile errors | 🟢 | tiberius. |
-| 317 | rustls duplicate-definition errors | 🟢 | tiberius. |
-| 42  | Replace BytesMut/Bytes with Vec | 🟢 | tiberius-internal refactor. |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 417 | `cargo audit` fails on rustls-webpki RUSTSEC-2026-0098/9/0104 | ✅ | [#37](../../issues/37) (PR [#38](../../pull/38)) — cargo-audit clean + weekly CI | **Check**: run `cargo audit` on bridge. mssql-tds uses native-tls so likely clean. |
+| 329 | Update tokio_rustls 0.24→0.25 | 🟢 | — | tiberius dep. |
+| 323 | TLS compile errors | 🟢 | — | tiberius. |
+| 317 | rustls duplicate-definition errors | 🟢 | — | tiberius. |
+| 42 | Replace BytesMut/Bytes with Vec | 🟢 | — | tiberius-internal refactor. |
 
 ## M. Misc / Out of Scope
 
-| # | Title | Status | Notes |
-|---|-------|--------|-------|
-| 199 | (closed/missing) | ⚪ | — |
+| # | Title | Status | Bridge | Notes |
+|---|-------|--------|--------|-------|
+| 199 | (closed/missing) | ⚪ | — | — |
 
 ---
 


### PR DESCRIPTION
Adds a **Bridge** column to every section table (A–M) in `docs/tiberius-issues-triage.md` so each row tells you, in-place, what the bridge has done about that tiberius issue — without scrolling to the cross-reference at the bottom.

**Before**

| # | Title | Status | Notes |
| 198 | Check if TCP connection is alive | 🔵 | Feature: `Client::ping` or `is_connected`. |

**After**

| # | Title | Status | Bridge | Notes |
| 198 | Check if TCP connection is alive | ✅ | [#44](../../issues/44) (PR [#45](../../pull/45)) — `Client::ping()` | Feature: `Client::ping` or `is_connected`. |

Status emoji updated to:
- ✅ where shipped (most rows)
- 🟡 where there's an open bridge tracking issue
- ⚪ where intentionally out-of-scope (legacy SQL Server, environment-specific, N/A)
- 🟢 where the row is genuinely tiberius-internal and never affected the bridge

Also fixed the obsolete callout under section D: BCP is shipped (#53/#84) and Apache Arrow input shipped (#85/#86).

Doc-only change.