### PR TITLE
fix(query): dispatch serde_json::Value ToSql by variant

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -706,10 +706,15 @@ mod tests {
 
     #[test]
     fn json_value_to_sql_dispatches_by_variant() {
-        assert!(matches!(serde_json::Value::Null.to_sql(), SqlType::NVarchar(None, 4000)));
+        assert!(matches!(
+            serde_json::Value::Null.to_sql(),
+            SqlType::NVarchar(None, 4000)
+        ));
         assert!(matches!(json!(true).to_sql(), SqlType::Bit(Some(true))));
         assert!(matches!(json!(42).to_sql(), SqlType::BigInt(Some(42))));
-        assert!(matches!(json!(3.14).to_sql(), SqlType::Float(Some(v)) if (v - 3.14).abs() < f64::EPSILON));
+        assert!(
+            matches!(json!(2.5).to_sql(), SqlType::Float(Some(v)) if (v - 2.5).abs() < f64::EPSILON)
+        );
 
         let ty = json!("alice").to_sql();
         assert!(matches!(ty, SqlType::NVarchar(_, 4000)));

--- a/src/query.rs
+++ b/src/query.rs
@@ -342,7 +342,25 @@ impl<T: ToSql + Default> ToSql for Option<T> {
 
 impl ToSql for serde_json::Value {
     fn to_sql(&self) -> SqlType {
-        SqlType::NVarchar(Some(SqlString::from_utf8_string(self.to_string())), 4000)
+        match self {
+            serde_json::Value::Null => SqlType::NVarchar(None, 4000),
+            serde_json::Value::Bool(value) => SqlType::Bit(Some(*value)),
+            serde_json::Value::Number(number) => {
+                if let Some(value) = number.as_i64() {
+                    SqlType::BigInt(Some(value))
+                } else if let Some(value) = number.as_f64() {
+                    SqlType::Float(Some(value))
+                } else {
+                    SqlType::Float(Some(f64::NAN))
+                }
+            }
+            serde_json::Value::String(value) => {
+                SqlType::NVarchar(Some(SqlString::from_utf8_string(value.clone())), 4000)
+            }
+            serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+                SqlType::NVarchar(Some(SqlString::from_utf8_string(self.to_string())), 4000)
+            }
+        }
     }
 }
 
@@ -621,6 +639,7 @@ pub(crate) fn build_params_with_string_encoding(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn to_sql_primitives() {
@@ -683,5 +702,33 @@ mod tests {
         let qr = QueryResult::empty();
         assert_eq!(qr.result_set_count(), 0);
         assert!(qr.into_first_result().is_empty());
+    }
+
+    #[test]
+    fn json_value_to_sql_dispatches_by_variant() {
+        assert!(matches!(serde_json::Value::Null.to_sql(), SqlType::NVarchar(None, 4000)));
+        assert!(matches!(json!(true).to_sql(), SqlType::Bit(Some(true))));
+        assert!(matches!(json!(42).to_sql(), SqlType::BigInt(Some(42))));
+        assert!(matches!(json!(3.14).to_sql(), SqlType::Float(Some(v)) if (v - 3.14).abs() < f64::EPSILON));
+
+        let ty = json!("alice").to_sql();
+        assert!(matches!(ty, SqlType::NVarchar(_, 4000)));
+        if let SqlType::NVarchar(Some(value), 4000) = ty {
+            assert_eq!(value.to_utf8_string(), "alice");
+        }
+
+        let array = json!([1, 2, 3]);
+        if let SqlType::NVarchar(Some(value), 4000) = array.to_sql() {
+            assert_eq!(value.to_utf8_string(), array.to_string());
+        } else {
+            panic!("expected NVarchar JSON text for array");
+        }
+
+        let object = json!({"name":"alice"});
+        if let SqlType::NVarchar(Some(value), 4000) = object.to_sql() {
+            assert_eq!(value.to_utf8_string(), object.to_string());
+        } else {
+            panic!("expected NVarchar JSON text for object");
+        }
     }
 }

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -534,14 +534,14 @@ async fn serde_json_value_param_variant_dispatch() {
         .into_first_result();
     assert_eq!(rows[0].get::<i64, _>(0usize), Some(42));
 
-    let float_value = json!(3.14);
+    let float_value = json!(2.5);
     let rows = client
         .query("SELECT @P1", &[&float_value])
         .await
         .unwrap()
         .into_first_result();
     let got_float = rows[0].get::<f64, _>(0usize).unwrap();
-    assert!((got_float - 3.14).abs() < f64::EPSILON);
+    assert!((got_float - 2.5).abs() < f64::EPSILON);
 
     let string_value = json!("alice");
     let rows = client

--- a/tests/tiberius_compat.rs
+++ b/tests/tiberius_compat.rs
@@ -1,5 +1,6 @@
 use chrono::TimeZone;
 use mssql_tiberius_bridge::{AuthMethod, Client, Config};
+use serde_json::json;
 
 fn test_config() -> Config {
     let password = match std::env::var("TEST_DB_PASSWORD") {
@@ -503,6 +504,74 @@ async fn datetime_utc_param_sends_offset_zero() {
         .unwrap();
     assert_eq!(got.naive_utc(), dt_utc.naive_utc());
     assert_eq!(got.offset().local_minus_utc(), 0);
+}
+
+#[tokio::test]
+async fn serde_json_value_param_variant_dispatch() {
+    let mut client = connect().await;
+
+    let null_value = serde_json::Value::Null;
+    let rows = client
+        .query("SELECT @P1", &[&null_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(rows[0].get::<Option<String>, _>(0usize), Some(None));
+
+    let bool_value = json!(true);
+    let rows = client
+        .query("SELECT @P1", &[&bool_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(rows[0].get::<bool, _>(0usize), Some(true));
+
+    let int_value = json!(42);
+    let rows = client
+        .query("SELECT @P1", &[&int_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(rows[0].get::<i64, _>(0usize), Some(42));
+
+    let float_value = json!(3.14);
+    let rows = client
+        .query("SELECT @P1", &[&float_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    let got_float = rows[0].get::<f64, _>(0usize).unwrap();
+    assert!((got_float - 3.14).abs() < f64::EPSILON);
+
+    let string_value = json!("alice");
+    let rows = client
+        .query("SELECT @P1", &[&string_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(rows[0].get::<String, _>(0usize), Some("alice".to_string()));
+
+    let array_value = json!([1, 2, 3]);
+    let rows = client
+        .query("SELECT @P1", &[&array_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(
+        rows[0].get::<String, _>(0usize),
+        Some(array_value.to_string())
+    );
+
+    let object_value = json!({"id": 1, "name": "alice"});
+    let rows = client
+        .query("SELECT @P1", &[&object_value])
+        .await
+        .unwrap()
+        .into_first_result();
+    assert_eq!(
+        rows[0].get::<String, _>(0usize),
+        Some(object_value.to_string())
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- fix ToSql for serde_json::Value to map by JSON variant instead of always JSON-stringifying
- preserve JSON text behavior for arrays/objects
- send plain string values as NVarchar("alice") instead of JSON-quoted "\"alice\""
- add unit tests in src/query.rs for variant-to-SqlType mapping
- add integration test in tests/tiberius_compat.rs using SELECT @P1 for each JSON variant

## Why
Issue #95 reports incorrect parameter typing for serde_json::Value, causing silent mismatches (notably Value::String) when used in predicates.

Fixes #95