### PR TITLE
Upgrade mssql-tds-preview to 0.1.0-preview.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "mssql-tds-preview"
-version = "0.1.0-preview.1"
+version = "0.1.0-preview.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454957bed59024ea56acb311e8c0b74369182f1a3256d9e036d4b46f687d0462"
+checksum = "0e88e1ab8a57f9ddfb43cd8ecab7bc4d388f7c234f8ed5334b1e35e94c7f9d7d"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -845,6 +845,7 @@ dependencies = [
  "dns-lookup",
  "encoding_rs",
  "futures",
+ "half",
  "hostname",
  "libc",
  "native-tls",
@@ -1537,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = ["dep:serde"]
 arrow = ["dep:arrow-array", "dep:arrow-schema"]
 
 [dependencies]
-mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.1", default-features = false }
+mssql-tds = { package = "mssql-tds-preview", version = "=0.1.0-preview.5", default-features = false }
 deadpool = "0.12"
 chrono = "0.4"
 rust_decimal = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ use mssql_tds::connection::client_context::{
     ClientContext, DriverVersion, TdsAuthenticationMethod,
 };
 use mssql_tds::core::EncryptionSetting;
+use std::path::PathBuf;
 
 /// The driver name sent in the TDS Login7 packet and UserAgent feature extension.
 /// Follows the MS driver naming convention (e.g., `MS-TDS`, `MS-PYTHON`).
@@ -164,7 +165,7 @@ pub struct Config {
     database: String,
     auth: AuthMethod,
     trust_cert: bool,
-    server_certificate: Option<String>,
+    server_certificate: Option<PathBuf>,
     host_name_in_certificate: Option<String>,
     readonly: bool,
     encryption: EncryptionLevel,
@@ -263,7 +264,7 @@ impl Config {
     /// let mut cfg = Config::new();
     /// cfg.host("db.internal").trust_cert_ca("/etc/ssl/private-ca.pem");
     /// ```
-    pub fn trust_cert_ca(&mut self, path: impl Into<String>) -> &mut Self {
+    pub fn trust_cert_ca(&mut self, path: impl Into<PathBuf>) -> &mut Self {
         self.server_certificate = Some(path.into());
         self
     }
@@ -563,25 +564,29 @@ mod tests {
 
     #[test]
     fn trust_cert_ca_sets_server_certificate() {
+        use std::path::Path;
+
         let mut cfg = Config::new();
         cfg.trust_cert_ca("/etc/ssl/ca.pem");
         let ctx = cfg.to_client_context();
         assert_eq!(
             ctx.encryption_options.server_certificate.as_deref(),
-            Some("/etc/ssl/ca.pem")
+            Some(Path::new("/etc/ssl/ca.pem"))
         );
         assert!(!ctx.encryption_options.trust_server_certificate);
     }
 
     #[test]
     fn trust_cert_ca_independent_of_trust_cert() {
+        use std::path::Path;
+
         let mut cfg = Config::new();
         cfg.trust_cert().trust_cert_ca("/tmp/ca.pem");
         let ctx = cfg.to_client_context();
         assert!(ctx.encryption_options.trust_server_certificate);
         assert_eq!(
             ctx.encryption_options.server_certificate.as_deref(),
-            Some("/tmp/ca.pem")
+            Some(Path::new("/tmp/ca.pem"))
         );
     }
 
@@ -754,6 +759,8 @@ mod tests {
 
     #[test]
     fn strict_preserves_host_name_in_certificate_and_ca() {
+        use std::path::Path;
+
         // Strict mode must still honour SNI override and custom CA bundle —
         // only `trust_cert` (TrustServerCertificate) is ignored by mssql-tds
         // under Strict.
@@ -764,7 +771,10 @@ mod tests {
         let opts = cfg.to_client_context().encryption_options;
         assert_eq!(opts.mode, mssql_tds::core::EncryptionSetting::Strict);
         assert_eq!(opts.host_name_in_cert.as_deref(), Some("sql.example.com"));
-        assert_eq!(opts.server_certificate.as_deref(), Some("/etc/ssl/ca.pem"));
+        assert_eq!(
+            opts.server_certificate.as_deref(),
+            Some(Path::new("/etc/ssl/ca.pem"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Upgrades mssql-tds-preview from =0.1.0-preview.1 to =0.1.0-preview.5
- Updates config TLS server certificate handling to match new PathBuf API
- Keeps formatting/lint/tests green after dependency upgrade

## Why
- preview.1 contains unresolved Numeric/Decimal TODO paths
- preview.5 removes the NumericN todo path and includes decimal/numeric decoding support

## Validation
- cargo test --lib
- cargo fmt --check
- cargo clippy --all-targets
- cargo test --test integration --no-run

All checks passed locally.
